### PR TITLE
Templated todo lists

### DIFF
--- a/fir_todos/admin.py
+++ b/fir_todos/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 
-from fir_todos.models import TodoItem
+from fir_todos.models import TodoItem,TodoListTemplate
 
 admin.site.register(TodoItem)
+admin.site.register(TodoListTemplate)

--- a/fir_todos/migrations/0002_auto_20160110_0223.py
+++ b/fir_todos/migrations/0002_auto_20160110_0223.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('incidents', '0002_auto_20150907_1147'),
+        ('fir_todos', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='TodoListTemplate',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(max_length=100)),
+                ('category', models.ForeignKey(blank=True, to='incidents.IncidentCategory', null=True)),
+                ('concerned_business_lines', models.ManyToManyField(to='incidents.BusinessLine', null=True, blank=True)),
+                ('detection', models.ForeignKey(blank=True, to='incidents.Label', null=True)),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+        migrations.AlterField(
+            model_name='todoitem',
+            name='incident',
+            field=models.ForeignKey(blank=True, to='incidents.Incident', null=True),
+            preserve_default=True,
+        ),
+    ]

--- a/fir_todos/migrations/0003_todolisttemplate_todolist.py
+++ b/fir_todos/migrations/0003_todolisttemplate_todolist.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('fir_todos', '0002_auto_20160110_0223'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='todolisttemplate',
+            name='todolist',
+            field=models.ManyToManyField(to='fir_todos.TodoItem', null=True, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/fir_todos/models.py
+++ b/fir_todos/models.py
@@ -2,7 +2,6 @@ from django.db import models
 from django import forms
 
 from incidents.models import Incident, IncidentCategory, BusinessLine, Label
-#from incidents.models import STATUS_CHOICES, SEVERITY_CHOICES
 
 class TodoItem(models.Model):
 	description = models.CharField(max_length=140)

--- a/fir_todos/models.py
+++ b/fir_todos/models.py
@@ -1,12 +1,12 @@
 from django.db import models
 from django import forms
 
-from incidents.models import Incident, IncidentCategory, BusinessLine
-
+from incidents.models import Incident, IncidentCategory, BusinessLine, Label
+#from incidents.models import STATUS_CHOICES, SEVERITY_CHOICES
 
 class TodoItem(models.Model):
 	description = models.CharField(max_length=140)
-	incident = models.ForeignKey(Incident)
+	incident = models.ForeignKey(Incident, blank=True, null=True)
 	category = models.ForeignKey(IncidentCategory)
 	business_line = models.ForeignKey(BusinessLine)
 	done = models.BooleanField(default=False)
@@ -24,3 +24,16 @@ class TodoItemForm(forms.ModelForm):
 		widgets = {
 			'description': forms.TextInput(attrs={'placeholder': 'Task'}),
 		}
+
+# Templating =================================================================
+
+class TodoListTemplate(models.Model):
+	name = models.CharField(max_length=100)
+	category = models.ForeignKey(IncidentCategory, null=True, blank=True)
+	concerned_business_lines = models.ManyToManyField(BusinessLine, null=True, blank=True)
+	detection = models.ForeignKey(Label, limit_choices_to={'group__name': 'detection'}, null=True, blank=True)
+	todolist = models.ManyToManyField(TodoItem, null=True, blank=True)
+
+
+	def __unicode__(self):
+		return self.name

--- a/incidents/views.py
+++ b/incidents/views.py
@@ -36,7 +36,7 @@ import math
 import collections
 
 from fir_artifacts import artifacts as libartifacts
-from fir_todos.models import TodoItem, TodoListTemplate
+from fir_todos.models import TodoListTemplate
 
 cal = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec']
 


### PR DESCRIPTION
In response to issue #39 I decided to take a stab at implementing templated todo lists. The implementation is fairly similar to incident templates.

Todo items are no longer required to be linked to an incident, so you can make some to use in your template.

You create a Todo list template and give it a category, detection, one or more business lines, and one or more todo items.

When an incident is created, a query is performed to look for todo list templates that may be appropriate to your incident. If one (or more than one) is found, the todo items associated with that todo list template are copied and saved as new todo items which are associated to the newly created incident.