### PR TITLE
Improve IP regex in fir_artifacts

### DIFF
--- a/fir_artifacts/ip.py
+++ b/fir_artifacts/ip.py
@@ -4,4 +4,4 @@ from fir_artifacts.artifacts import AbstractArtifact
 class IP(AbstractArtifact):
 	key = 'ip'
 	display_name = 'IPS'
-	regex = r"(?P<search>[\d+]{1,3}\.[\d+]{1,3}\.[\d+]{1,3}\.[\d+]{1,3})"
+	regex = r'(([^\d])|^)(?P<search>(([2][5][0-5]\.)|([2][0-4][0-9]\.)|([0-1]?[0-9]?[0-9]\.)){3}(([2][5][0-5])|([2][0-4][0-9])|([0-1]?[0-9]?[0-9])))(([^\d]|$))'


### PR DESCRIPTION
Hi,

Better extraction of IPv4 addresses (each byte must be less than 256).

Gaetan