### PR TITLE
Add very basic travis file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: python
 
 python:
     - "2.7"
-    - "3.3"
-    - "3.4"
-    - "3.5"
-    - "nightly"
+      #- "3.3"
+      #- "3.4"
+      #- "3.5"
+      #- "nightly"
 
 dist: trusty
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,46 @@
+language: python
+
+python:
+    - "2.7"
+    - "3.3"
+    - "3.4"
+    - "3.5"
+    - "nightly"
+
+dist: trusty
+
+group: edge
+
+addons:
+    apt:
+        packages:
+            # General dependencies
+            - python-dev
+            - python-pip
+            - python-lxml
+            - git
+            - libxml2-dev
+            - libxslt1-dev
+            - libz-dev
+
+install:
+    - pip install -U pip
+    - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then pip install -r requirements.txt ; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then pip install -r requirements_py3.txt ; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == nightly ]]; then pip install -r requirements_py3.txt ; fi
+    - cp fir/config/installed_apps.txt.sample fir/config/installed_apps.txt
+    - ./manage.py migrate
+
+
+script:
+    - ./manage.py loaddata incidents/fixtures/seed_data.json
+    - ./manage.py loaddata incidents/fixtures/dev_users.json
+    - ./manage.py runserver &
+    - sleep 20
+    - curl -L http://127.0.0.1:8000
+    - sleep 10
+
+notifications:
+    email:
+        on_success: change
+        on_failure: change

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/certsocietegenerale/FIR.svg?branch=master)](https://travis-ci.org/certsocietegenerale/FIR)
+
 # What is FIR? Who is it for?
 
 FIR (Fast Incident Response) is an cybersecurity incident management platform designed with agility and speed in mind. It allows for easy creation, tracking, and reporting of cybersecurity incidents.
@@ -32,4 +34,4 @@ FIR is not greedy performance-wise. It will run smoothly on a Ubuntu 14.04 virtu
 * Nested Todos
 * REST API
 * Mailman
-* You name it :) 
+* You name it :)

--- a/requirements_py3.txt
+++ b/requirements_py3.txt
@@ -1,0 +1,13 @@
+django>=1.9,<1.10
+djangorestframework
+markdown
+django-filter
+argparse==1.2.1
+cssselect==0.9.1
+git+https://github.com/pquentin/flup-py3.git
+lxml==3.4.2
+pymongo==2.8
+pyquery==1.2.9
+python-dateutil==2.4.1
+pytz==2014.10
+six==1.9.0


### PR DESCRIPTION
There is also a partial support to run travis on python 3 but the platform doesn't supports it (and a quick&dirty 2to3 didn't do the trick).