### PR TITLE
Basic python3 compatibility

### DIFF
--- a/fir_alerting/views.py
+++ b/fir_alerting/views.py
@@ -28,7 +28,7 @@ def get_template(request, incident_id, template_type, bl=None):
 
     try:
         cat_template = CategoryTemplate.objects.get(incident_category=i.category, type=template_type)
-    except Exception, e:
+    except Exception as e:
         cat_template = None
 
     rec_template = None
@@ -45,8 +45,8 @@ def get_template(request, incident_id, template_type, bl=None):
 
     try:
         rec_template = RecipientTemplate.objects.get((q_bl | Q(business_line=None)) & Q(type=template_type))
-    except Exception, e:
-        print "Email template ERROR: ", e
+    except Exception as e:
+        print("Email template ERROR: ", e)
         parents = list(set(i.concerned_business_lines.all()))
 
         while not rec_template and parents != [None]:
@@ -59,7 +59,7 @@ def get_template(request, incident_id, template_type, bl=None):
                 if len(template) > 0:
                     rec_template = template[0]
             except Exception as e:
-                print "Email template ERROR 2: ", e
+                print("Email template ERROR 2: ", e)
                 break
 
     artifacts = {}
@@ -121,7 +121,7 @@ def send_email(request):
 
             return HttpResponse(dumps({'status': 'ok'}), content_type="application/json")
 
-        except Exception, e:
+        except Exception as e:
             return HttpResponse(dumps({'status': 'ko', 'error': str(e)}), content_type="application/json")
 
     return HttpResponseBadRequest(dumps({'status': 'ko'}), content_type="application/json")

--- a/fir_api/views.py
+++ b/fir_api/views.py
@@ -1,5 +1,9 @@
-# for token Generation
-import StringIO
+# To be compatible with python 2&3 we us an elegant
+# import switch here.
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 from django.conf import settings
 from django.db.models.signals import post_save

--- a/incidents/views.py
+++ b/incidents/views.py
@@ -114,7 +114,7 @@ def log(what, user, incident=None, comment=None):
     # dirty hack to not log when in debug mode
     import sys
     if len(sys.argv) >= 2 and sys.argv[1] == 'runserver':
-        print "DEBUG: Not logging"
+        print("DEBUG: Not logging")
         return
 
     log = Log()


### PR DESCRIPTION
Basic changes to the code base to fix obvious python3 compatibility issues.
To run FIR with py3, requirements.txt needs to be adjusted for flup (only dev version for py3) and wsgiref (included in py3) changes:

```
django>=1.9,<1.10
djangorestframework
markdown
django-filter
argparse==1.2.1
cssselect==0.9.1
flup==1.0.3.dev20151210
lxml==3.4.2
pymongo==2.8
pyquery==1.2.9
python-dateutil==2.4.1
pytz==2014.10
six==1.9.0
```

Let's push FIR to the future :)
