### PR TITLE
Deploy to Heroku button in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you like it and want to set it up for production, [here's how to do it](https
 
 A dockerfile for running a dev-quality FIR setup is also available in [docker/Dockerfile](docker/Dockerfile).
 
-Deploy to [Heroku](https://heroku.com) via fir/heroku_settings.py
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy) via fir/heroku_settings.py
 
 # Community
 

--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
   "description": "Fast Incident Response",
   "repository": "https://github.com/certsocietegenerale/FIR.git",
   "logo": "https://raw.githubusercontent.com/certsocietegenerale/FIR/master/incidents/static/img/logo.jpg",
-  "keywords": ["security", "django", "dfir"]
+  "keywords": ["security", "django", "dfir"],
   "env": {
     "DISABLE_COLLECTSTATIC": 1
   },

--- a/app.json
+++ b/app.json
@@ -4,4 +4,14 @@
   "repository": "https://github.com/certsocietegenerale/FIR.git",
   "logo": "https://raw.githubusercontent.com/certsocietegenerale/FIR/master/incidents/static/img/logo.jpg",
   "keywords": ["security", "django", "dfir"]
+  "env": {
+    "DISABLE_COLLECTSTATIC": 1
+  },
+  "scripts": {
+    "postdeploy": [
+      "python manage.py migrate",
+      "cp fir/config/installed_apps.txt.sample fir/config/installed_apps.txt",
+      "python manage.py loaddata incidents/fixtures/seed_data.json"
+    ]
+  }  
 }

--- a/app.json
+++ b/app.json
@@ -1,0 +1,7 @@
+{
+  "name": "FIR",
+  "description": "Fast Incident Response",
+  "repository": "https://github.com/certsocietegenerale/FIR.git",
+  "logo": "https://raw.githubusercontent.com/certsocietegenerale/FIR/master/incidents/static/img/logo.jpg",
+  "keywords": ["security", "django", "dfir"]
+}


### PR DESCRIPTION
Added some syntactic sugar for the deploy to Heroku option through a Deploy button. The initial build will not run properly because it needs database migrations and the heroku_settings file to be activated, but still simplifies deploy a bit.

<img width="524" alt="screen shot 2016-08-31 at 8 17 51 am" src="https://cloud.githubusercontent.com/assets/6267544/18134713/2c1f1922-6f54-11e6-8677-eca1a6441dc9.png">
 