### PR TITLE
Formatting incident IDs in views using the new links registry

### DIFF
--- a/fir/config/base.py
+++ b/fir/config/base.py
@@ -129,6 +129,9 @@ TEMPLATES = [
 # Show incident IDs in views?
 INCIDENT_SHOW_ID = False
 
+# Incident ID prefix in views and links
+INCIDENT_ID_PREFIX = "FID:"
+
 # Permission added to the incident created by user, None for no permission
 INCIDENT_CREATOR_PERMISSION = 'incidents.view_incidents'
 

--- a/fir_artifacts/views.py
+++ b/fir_artifacts/views.py
@@ -2,6 +2,7 @@ from django.contrib.auth.decorators import login_required, user_passes_test
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.shortcuts import get_object_or_404, render, redirect
+from django.conf import settings
 from fir_artifacts.files import do_download_archive, do_download, do_upload_file, do_remove_file
 
 from incidents.views import is_incident_viewer
@@ -14,7 +15,9 @@ from fir_artifacts.models import Artifact
 def artifacts_correlations(request, artifact_id):
     a = get_object_or_404(Artifact, pk=artifact_id)
     correlations = a.relations.group()
-    return render(request, 'fir_artifacts/correlation_list.html', {'correlations': correlations, 'artifact': a})
+    return render(request, 'fir_artifacts/correlation_list.html', {'correlations': correlations,
+                                                                   'artifact': a,
+                                                                   'incident_show_id': settings.INCIDENT_SHOW_ID})
 
 
 @login_required

--- a/fir_plugins/links.py
+++ b/fir_plugins/links.py
@@ -4,6 +4,18 @@ from django.utils import six
 import re
 
 
+class LinkUrl(object):
+    def __init__(self, url, request=None):
+        self.url = url
+        self.request = request
+
+    def __call__(self, match):
+        path = reverse(self.url, args=match.groups())
+        if self.request is not None:
+            return self.request.build_absolute_uri(path)
+        return path
+
+
 class Links(object):
     def __init__(self):
         self.reverse_links = []
@@ -39,12 +51,7 @@ class Links(object):
     def _reverse(self, request=None):
         patterns = []
         for regex, url in self.reverse_links:
-            def get_url(match):
-                path = reverse(url, args=match.groups())
-                if request is not None:
-                    return request.build_absolute_uri(path)
-                return path
-            patterns.append((regex, get_url))
+            patterns.append((regex, LinkUrl(url, request)))
         return patterns
 
     def link_patterns(self, request=None):

--- a/fir_plugins/templatetags/fir_plugins.py
+++ b/fir_plugins/templatetags/fir_plugins.py
@@ -4,6 +4,7 @@ from django.utils.html import mark_safe
 from django.template import TemplateDoesNotExist
 from django.template.loader import get_template
 from django.contrib.contenttypes.models import ContentType
+from ..links import registry
 
 register = template.Library()
 
@@ -37,3 +38,11 @@ def content_type(obj):
     if not obj:
         return False
     return ContentType.objects.get_for_model(obj).pk
+
+
+@register.filter
+def object_id(obj):
+    id_template = registry.model_links.get(obj._meta.label, ['', '', None])[2]
+    if not id_template:
+        id_template = "#{}"
+    return id_template.format(obj.pk)

--- a/incidents/apps.py
+++ b/incidents/apps.py
@@ -6,4 +6,6 @@ class IncidentsConfig(AppConfig):
 
     def ready(self):
         from fir_plugins.links import registry
-        registry.register_reverse_link("FID:(\d+)", 'incidents:details', model='incidents.Incident', reverse="#{}")
+        from django.conf import settings
+        registry.register_reverse_link(settings.INCIDENT_ID_PREFIX + "(\d+)", 'incidents:details',
+                                       model='incidents.Incident', reverse=settings.INCIDENT_ID_PREFIX + "{}")

--- a/incidents/templates/events/detail-all.html
+++ b/incidents/templates/events/detail-all.html
@@ -101,7 +101,7 @@
 			</table>
 		</div>
 
-		<h1>{% if event.is_incident %}{%  trans "Incident" %}{% else %}{%  trans "Event" %}{% endif %}{% if incident_show_id %} #{{ event.id }}{% endif %} / {{event.category}} / {{event.subject}}</h1>
+		<h1>{% if event.is_incident %}{%  trans "Incident" %}{% else %}{%  trans "Event" %}{% endif %}{% if incident_show_id %} {{ event|object_id }}{% endif %} / {{event.category}} / {{event.subject}}</h1>
 		<div class="row">
 			<div class="col-sm-7 col-xs-12">
                 {% trans "someone" as someone %}

--- a/incidents/templates/events/table.html
+++ b/incidents/templates/events/table.html
@@ -1,5 +1,6 @@
 {% load i18n %}
 {% load authorization %}
+{% load fir_plugins %}
 {% if incident_list %}
 	<div class='incident_table' data-order-param='{{ order_param }}' data-asc='{{ asc }}'>
 		<table class='table table-hover table-condensed'>
@@ -40,7 +41,7 @@
 				{% for incident in incident_list %}
 					{%  has_perm 'incidents.handle_incidents' obj=incident as can_handle_incident %}
 					<tr class='{{ incident.status }}'>
-						{% if incident_show_id %}<td>#{{ incident.id|stringformat:"04d" }}</td>{% endif %}
+						{% if incident_show_id %}<td>{{ incident|object_id }}</td>{% endif %}
 						<td class='incident_date_column'>{{ incident.date|date:'Y-m-d' }}</td>
 						<td>
 							{% if can_handle_incident %}<a href="{% url 'ajax:toggle_star' incident.id %}" class='star'>{%endif%}

--- a/incidents/templates/incidents/followup.html
+++ b/incidents/templates/incidents/followup.html
@@ -27,7 +27,7 @@
 
 		<table class='minitable table'>
 			<tr class='slim'>
-				{% if incident_show_id %}<td class='head'>ID</td><td class='delim'>#{{ incident.id }}</td>{% endif %}
+				{% if incident_show_id %}<td class='head'>ID</td><td class='delim'>{{ incident|object_id }}</td>{% endif %}
 				{%if incident.is_incident%}
 				<td class='head'>{%  trans "Incident Leader" %}</td><td class='delim'>{{ incident.actor }}</td>
 				<td class='head'>{%  trans "Plan" %}</td><td class='delim'>{{ incident.plan }}</td>

--- a/incidents/templates/incidents/plugins/correlation_list.html
+++ b/incidents/templates/incidents/plugins/correlation_list.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load fir_plugins %}
 {% load authorization %}
 {% block content %}
     {% with incident_list=correlations.incidents.objects %}
@@ -8,6 +9,7 @@
 
 			<thead>
 				<tr>
+                    {% if incident_show_id %}<th>ID</th>{% endif %}
 					<th>{% trans "Date" %}</th>
 					<th>{% trans "Subject" %}</th>
 					<th>{% trans "Category" %}</th>
@@ -25,6 +27,7 @@
         {%  has_perm 'incidents.handle_incidents' obj=incident as can_handle_incident %}
         {% if can_view_incident %}
 		<tr>
+            {% if incident_show_id %}<td>{{ incident|object_id }}</td>{% endif %}
 			<td>{{ incident.date|date:"SHORT_DATE_FORMAT" }}</td>
 			<td><a href="{% url 'incidents:details' incident.id %}">{{ incident.subject }}</a></td>
 			<td>{{ incident.category }}</td>

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ python-dateutil==2.4.1
 pytz==2014.10
 six==1.9.0
 whitenoise==3.2.1
-django-treebeard==4.0.1
+django-treebeard==4.1.0
 markdown2==2.3.1


### PR DESCRIPTION
- Incident ID prefix in settings: when parsing Markdown in description and comment (default 'FID:')
- Use this prefix in views if INCIDENT_SHOW_ID is True (default: False)
- Update django-treebeard to avoid Django 1.10 compatibility warning