### PR TITLE
Bug DataError: (1406, "Data too long for column value at row 1")

### DIFF
--- a/fir_artifacts/models.py
+++ b/fir_artifacts/models.py
@@ -14,7 +14,7 @@ class ArtifactBlacklistItem(models.Model):
 
 class Artifact(ManyLinkableModel):
     type = models.CharField(max_length=20)
-    value = models.CharField(max_length=200)
+    value = models.TextField()
 
     def __unicode__(self):
         display = self.value


### PR DESCRIPTION
Can you change type of field value for artifact model... Value field type char max 200 is undersized because sometimes uri is bigger than 200 chars and cause error 500 (DataError: (1406, "Data too long for column 'value' at row 1")).
This error stop the process of creation...
Thank for your tool!
Sincerly,
Lionel