### PR TITLE
Document fir_celery, fir_abuse, fir_artifacts_enrichment

### DIFF
--- a/fir_abuse/README.md
+++ b/fir_abuse/README.md
@@ -1,0 +1,41 @@
+## Install
+Follow the generic plugin installation instructions in [the FIR wiki](https://github.com/certsocietegenerale/FIR/wiki/Plugins).
+
+| FIR plugin requirements   |                                                                                           |
+| ------------------------- | ----------------------------------------------------------------------------------------- |
+| fir_celery                | [[link]](https://github.com/certsocietegenerale/FIR/tree/master/fir_celery)               |
+| fir_artifacts_enrichement | [[link]](https://github.com/certsocietegenerale/FIR/tree/master/fir_artifacts_enrichment) |
+
+You should also make sure to configure your FIR instance so that it is able to send emails (see `EMAIL_HOST`, `EMAIL_PORT` and `REPLY_TO` in the configuration file).
+
+
+## Usage
+
+The `fir_abuse` plugin adds a **context menu** to be displayed when you right click on an artifact link on the incident details page.
+
+Thanks to a **visual indicator** this context menu offers a feedback on the **enrichement task** fired in the background upon **each artifact creation** (provided by the two required plugins).
+
+The enrichement task consists mainly in a **search** for an **abuse contact**. [[more info]](https://github.com/certsocietegenerale/FIR/tree/master/fir_artifacts_enrichment)
+
+Clicking on **Send Abuse** in the context menu, opens a _Send Email Abuse_ modal form.
+
+The form comes pre-filled with data from templates and contact info, which you can define from the FIR admin panel:
+
+* __Abuse Templates__: `name`, `type`, `body`, `subject` and `incident_category` are the five attributes that define an abuse template. The abuse email's _subject_ and _body_ for a specific incident category are filled thanks to these templates. When trying to find a template, FIR will look for the most specific one.
+* __Abuse Contact__: is a **_qualified contact information_** that helps define the upper part of the email form: `to`, `cc` and `bcc`. Each contact is specific to an `incident_category` and a `type`. FIR choose the right one depending on thoses parameters. The following variables are available by default in the context:
+  * subject: name of the incident
+  * bls: name of concerned business line
+  * artifacts: dictionary of artifacts
+  * incident_id: incident id
+  * incident_category: category's name
+  * artifact: artifact value
+  * enrichment: enrichment raw content
+
+If an __Abuse Contact__ exists it's always used to fill the upper part of the form, otherwise it's the email found through the enrichment process.
+
+> The form also contain an __Enrichment tab__ providing the `raw` result of the enrichement task.
+
+You should define your __Abuse Templates__ and qualified __Abuse Contact__ by connecting to FIR admin and adding objects to the "Abuse templates" and "Abuse contact" tables.
+
+### TODO
+Add the possibility to save the abuse email found through the enrichment task to the Abuse contact base

--- a/fir_abuse/README.md
+++ b/fir_abuse/README.md
@@ -31,9 +31,9 @@ The form comes pre-filled with data from templates and contact info, which you c
   * artifact: artifact value
   * enrichment: enrichment raw content
 
-If an __Abuse Contact__ exists it's always used to fill the upper part of the form, otherwise it's the email found through the enrichment process.
+If an __Abuse Contact__ exists it's always used to fill the upper part of the form, otherwise it's the __Email__ found through the enrichment process.
 
-> The form also contain an __Enrichment tab__ providing the `raw` result of the enrichement task.
+> The form also contain an __Enrichment tab__ providing the `raw` result of the enrichment task.
 
 You should define your __Abuse Templates__ and qualified __Abuse Contact__ by connecting to FIR admin and adding objects to the "Abuse templates" and "Abuse contact" tables.
 

--- a/fir_abuse/static/fir_abuse/js/abuse.js
+++ b/fir_abuse/static/fir_abuse/js/abuse.js
@@ -130,7 +130,7 @@ $(function () {
       + "-" + date.getDate() + " " + date.getHours()
       + ":" + date.getMinutes()
 
-    comment_ = 'Abuse email sent to ' + $('#sendAbuseEmail').data('artifact')
+    comment_ = 'Abuse email sent to ' + $('#sendAbuseEmail #abuse_to').val()
     action_ = $("#id_action option:contains('Abuse')").attr('value')
 
     $.ajax({

--- a/fir_artifacts_enrichment/README.md
+++ b/fir_artifacts_enrichment/README.md
@@ -1,0 +1,30 @@
+## Install
+Follow the generic plugin installation instructions in [the FIR wiki](https://github.com/certsocietegenerale/FIR/wiki/Plugins).
+
+| FIR plugin requirements   |                                                                               |
+| ------------------------- | ----------------------------------------------------------------------------- |
+| fir_abuse                 | [[link]](https://github.com/y9mo/FIR/tree/master/fir_abuse)                   |
+| fir_celery                | [[link]](https://github.com/certsocietegenerale/FIR/tree/master/fir_celery)   |
+
+
+__Python Package Index (PyPI) requirements __
+* abuse_finder [[link]](https://pypi.python.org/pypi/abuse-finder)
+
+## Usage
+
+You have nothing to do, that's the whole point. Just sit back and enjoy the ride ;)
+
+The `fir_artifacts_enrichment` plugin defines a __celery__ task that can be performed by a worker in the background.
+
+It relies on the `abuse_finder` package to perform an action depending on the `artifact.type`
+
+```python
+ENRICHMENT_FUNCTIONS = {
+    'hostname': domain_abuse,
+    'ip': ip_abuse,
+    'email': email_abuse,
+    'url': url_abuse
+}
+```
+
+The result of this task is then kept into FIR database and can be used by `fir_abuse` plugin

--- a/fir_celery/README.md
+++ b/fir_celery/README.md
@@ -1,0 +1,19 @@
+## Install
+Follow the generic plugin installation instructions in [the FIR wiki](https://github.com/certsocietegenerale/FIR/wiki/Plugins).
+
+__Python Package Index (PyPI) requirements__
+* celery
+* redis
+
+__Database requirement__
+* Redis
+
+This plugin uses __redis__ as a broker and result backend. As a consequence, you should make sure to provide your FIR instance with the following ( `REDIS_HOST`, `REDIS_PORT` and `REDIS_DB` in the configuration file).
+
+
+## Usage
+
+Start a worker instance by using the __celery__ program. This is enough for testing/dev purpose but in production you will want to run your worker as a [daemon](http://docs.celeryproject.org/en/latest/userguide/daemonizing.html#daemonizing)
+```bash
+$ celery -A fir_celery.celeryconf worker -l info
+```

--- a/fir_celery/README.md
+++ b/fir_celery/README.md
@@ -8,12 +8,14 @@ __Python Package Index (PyPI) requirements__
 __Database requirement__
 * Redis
 
-This plugin uses __redis__ as a broker and result backend. As a consequence, you should make sure to provide your FIR instance with the following ( `REDIS_HOST`, `REDIS_PORT` and `REDIS_DB` in the configuration file).
+The `fir_celery` plugin uses __redis__ as a broker and result backend. As a consequence, you should make sure to provide your FIR instance with the following ( `REDIS_HOST`, `REDIS_PORT` and `REDIS_DB` in the configuration file).
 
 
 ## Usage
-
 Start a worker instance by using the __celery__ program. This is enough for testing/dev purpose but in production you will want to run your worker as a [daemon](http://docs.celeryproject.org/en/latest/userguide/daemonizing.html#daemonizing)
 ```bash
 $ celery -A fir_celery.celeryconf worker -l info
 ```
+
+### TODO
+Improve this integration of celery as we add more tasks

--- a/fir_celery/celeryconf.py
+++ b/fir_celery/celeryconf.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
-from pkgutil import find_loader
 from celery import Celery
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'fir.settings')
@@ -9,19 +8,15 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'fir.settings')
 from django.conf import settings
 
 
-includes = []
-for app in settings.INSTALLED_APPS:
-    if app.startswith('fir_'):
-        module_name = "{}.tasks".format(app)
-        if find_loader(module_name):
-            includes.append(module_name)
-
 celery_app = Celery(
     'celeryconf',
-    broker='redis://%s:%d/%d' % (settings.REDIS_HOST, settings.REDIS_PORT, settings.REDIS_DB),
-    backend='redis://%s:%d/%d' % (settings.REDIS_HOST, settings.REDIS_PORT, settings.REDIS_DB),
-    include=includes
-)
+    broker='redis://%s:%d/%d' % (settings.REDIS_HOST, settings.REDIS_PORT,
+        settings.REDIS_DB),
+    backend='redis://%s:%d/%d' % (settings.REDIS_HOST, settings.REDIS_PORT,
+        settings.REDIS_DB)
+    )
+
+celery_app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hello,

I wrote a README for each of the following plugin `fir_celery`, `fir_abuse` and `fir_artifacts_enrichment`. Let me know if you think picture should be provided.

I made a minor change on the `fir_celery` plugin `celeryconf.py` nothing fancy, i replaced the following lines

```python
includes = []
for app in settings.INSTALLED_APPS:		
    if app.startswith('fir_'):		
        module_name = "{}.tasks".format(app)		
        if find_loader(module_name):		
            includes.append(module_name)
```

by this one

```python
celery_app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
```
as it does the exact same thing (load task modules from all registered Django app)