### PR TITLE
Sanitize Markdown2 HTML output

### DIFF
--- a/fir/config/base.py
+++ b/fir/config/base.py
@@ -144,6 +144,25 @@ INCIDENT_VIEWER_CAN_COMMENT = True
 # Escape HTML when displaying markdown
 MARKDOWN_SAFE_MODE = True
 
+# Allowed HTML tags in Markdown output (requires MARKDOWN_SAFE_MODE to be True)
+MARKDOWN_ALLOWED_TAGS = [
+    'a',
+    'abbr',
+    'acronym',
+    'b',
+    'blockquote',
+    'code',
+    'em',
+    'i',
+    'li',
+    'ol',
+    'strong',
+    'ul',
+    'p',
+    'h1', 'h2', 'h3', 'h4',
+    'table', 'thead', 'th', 'tbody', 'tr', 'td'
+]
+
 # User self-service features
 USER_SELF_SERVICE = {
     # User can change his own email address

--- a/fir_plugins/templatetags/markdown.py
+++ b/fir_plugins/templatetags/markdown.py
@@ -3,6 +3,7 @@ from django.templatetags.static import static
 from django.utils.safestring import mark_safe
 from django.conf import settings
 import markdown2
+import bleach
 
 from ..links import registry
 
@@ -39,4 +40,6 @@ def render_markdown(data):
     html = markdown2.markdown(data, extras=["link-patterns", "tables", "code-friendly"],
                               link_patterns=registry.link_patterns(),
                               safe_mode=settings.MARKDOWN_SAFE_MODE)
+    if settings.MARKDOWN_SAFE_MODE:
+        html = bleach.clean(html, tags=settings.MARKDOWN_ALLOWED_TAGS)
     return mark_safe(html)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ six==1.9.0
 whitenoise==3.2.1
 django-treebeard==4.1.0
 markdown2==2.3.1
+bleach==1.5.0


### PR DESCRIPTION
Mardown2 HTML output is not completeley sanitized with its `safe_mode` option as reported in #169 . Non-closed tags are not removed.

This PR uses `bleach`to sanitize the generated HTML. The new setting `MARKDOWN_ALLOWED_TAGS` is used to configure a tag whitelist. HTML tags used by Markdown2 extras are whitelisted.