### PR TITLE
Markdown : allow fenced code blocks

### DIFF
--- a/fir_plugins/templatetags/markdown.py
+++ b/fir_plugins/templatetags/markdown.py
@@ -39,7 +39,7 @@ def rich_edit(context, field):
 
 @register.filter(name='markdown')
 def render_markdown(data):
-    html = markdown2.markdown(data, extras=["link-patterns", "tables", "code-friendly"],
+    html = markdown2.markdown(data, extras=["link-patterns", "tables", "code-friendly", "fenced-code-blocks"],
                               link_patterns=registry.link_patterns(),
                               safe_mode=settings.MARKDOWN_SAFE_MODE)
     if settings.MARKDOWN_SAFE_MODE:


### PR DESCRIPTION
Simple PR to allow fenced code blocks in Markdown2 rendering

ex:

\`\`\`
var = "code block"
\`\`\`


```
var = "code block"
```
