### PR TITLE
Fix failing authorization unit tests

### DIFF
--- a/incidents/authorization/tests.py
+++ b/incidents/authorization/tests.py
@@ -6,6 +6,9 @@ from incidents import models
 
 # Create your tests here.
 
+def get_permission_for_app(codename, app_label='incidents'):
+    return Permission.objects.get(codename=codename, content_type__app_label=app_label)
+
 
 class BusinessLineTestCase(TestCase):
     def setUp(self):
@@ -33,9 +36,9 @@ class BusinessLineTestCase(TestCase):
 
         self.user5.groups.add(changer)
 
-        add = Permission.objects.get(codename='add_incident')
-        change = Permission.objects.get(codename='change_incident')
-        delete = Permission.objects.get(codename='delete_incident')
+        add = get_permission_for_app(codename='add_incident')
+        change = get_permission_for_app(codename='change_incident')
+        delete = get_permission_for_app(codename='delete_incident')
 
         adder.permissions.clear()
         adder.permissions.add(add)
@@ -101,9 +104,9 @@ class IncidentTestCase(TestCase):
 
         self.user5.groups.add(changer)
 
-        add = Permission.objects.get(codename='add_incident')
-        change = Permission.objects.get(codename='change_incident')
-        delete = Permission.objects.get(codename='delete_incident')
+        add = get_permission_for_app(codename='add_incident')
+        change = get_permission_for_app(codename='change_incident')
+        delete = get_permission_for_app(codename='delete_incident')
 
         adder.permissions.clear()
         adder.permissions.add(add)
@@ -204,9 +207,9 @@ class QuerySetBLTestCase(TestCase):
 
         self.user5.groups.add(changer)
 
-        add = Permission.objects.get(codename='add_incident')
-        change = Permission.objects.get(codename='change_incident')
-        delete = Permission.objects.get(codename='delete_incident')
+        add = get_permission_for_app(codename='add_incident')
+        change = get_permission_for_app(codename='change_incident')
+        delete = get_permission_for_app(codename='delete_incident')
 
         adder.permissions.clear()
         adder.permissions.add(add)


### PR DESCRIPTION
# Fix failing authorization unit tests

Whenever you clone the repository for the first time and run `python manage.py test`, you get failures for the authorization unit tests, with the following messages:

```
======================================================================
ERROR: test_tree_permission (incidents.authorization.tests.QuerySetBLTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/cristi/sandbox/FIR/incidents/authorization/tests.py", line 207, in setUp
    add = Permission.objects.get(codename='add_incident')
  File "/home/cristi/anaconda2/lib/python2.7/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/home/cristi/anaconda2/lib/python2.7/site-packages/django/db/models/query.py", line 384, in get
    (self.model._meta.object_name, num)
MultipleObjectsReturned: get() returned more than one Permission -- it returned 2!

----------------------------------------------------------------------
```

This occurs because of the 'add_incident' codename being present both in `incidents` and in `fir_plugins`. In order to fix the issue, one needs to get the permission from the incidents app.
