### PR TITLE
Remove empty continuation line

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,6 @@ RUN apk add --update \
     libxslt \
     libxslt-dev \
     postgresql-dev \
-
     && rm -rf /var/cache/apk/*
 
 RUN addgroup fir && \


### PR DESCRIPTION
During `docker build` the following warning message appears:
```
[WARNING]: Empty continuation line found in:
    RUN apk add --update     python     python-dev     py-pip     build-base     git     libxml2     libxml2-dev     libxslt     libxslt-dev     postgresql-dev     && rm -rf /var/cache/apk/*
[WARNING]: Empty continuation lines will become errors in a future release.
```

This change removes the empty continuation line.