### PR TITLE
Bump Alpine Linux from 3.4 to 3.7 to fix OpenSSL SSL_ERROR_SYSCALL, e…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@
 # then access http://localhost:8000 in your browser
 
 # MAINTAINER Robert Haist, SleuthKid@mailbox.org
-FROM alpine:3.4
+FROM alpine:3.7
 
 RUN apk add --update \
     python \


### PR DESCRIPTION
Cloning the FIR repository in git is throwing a curl 56 OpenSSL SSL_read: SSL_ERROR_SYSCALL, errno 104 error when connecting to GitHub; this commit bumps the base Alpine Linux image from v3.4 to v3.7 (latest stable) to fix the issue.