### PR TITLE
allow javascript access to the CSRF cookie

### DIFF
--- a/fir/config/base.py
+++ b/fir/config/base.py
@@ -189,8 +189,6 @@ MARKDOWN_SAFE_MODE = True
 ALLOWED_HOSTS = ["127.0.0.1", "0.0.0.0"]
 CSRF_TRUSTED_ORIGINS = ['http://' + h for h in ALLOWED_HOSTS] + ['https://' + h for h in ALLOWED_HOSTS]
 
-CSRF_COOKIE_HTTPONLY = True
-
 if bool(strtobool(os.getenv('HTTPS', 'False'))):
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True


### PR DESCRIPTION
Setting this cookie to httponly causes issues with XHR requests done by fir_alerting