### PR TITLE
Fixing the 'bl' GET argument in /api/incidents

### DIFF
--- a/fir_api/views.py
+++ b/fir_api/views.py
@@ -56,7 +56,7 @@ class IncidentViewSet(viewsets.ModelViewSet):
          if description is not None:
              q = q & Q(description__icontains=description)
          if bl is not None:
-             q = q & (Q(concerned_business_lines__in=bls) | Q(main_business_lines__in=[bls]))
+             q = q & (Q(concerned_business_lines__in=bl) | Q(main_business_lines__in=[bl]))
          if status is not None:
              q = q & Q(status=status)
          queryset = queryset.filter(q)


### PR DESCRIPTION
When requesting /api/incidents and specifying the "bl" argument the application raised a NameError exception.

That's because the code retrieves the "bl" argument in a variable named "bl" but then tries to filter against a variable named "bls". This fix renames bls to bl.