### PR TITLE
Always make migrations before running FIR in a docker container

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       context: ../
       dockerfile: docker/Dockerfile
     entrypoint: /bin/sh
-    command: -c "wait-for -t 10 fir_db:3306 && python manage.py migrate && python manage.py loaddata incidents/fixtures/*.json && python manage.py collectstatic --no-input && python manage.py runserver 0.0.0.0:8000"
+    command: -c "wait-for -t 10 fir_db:3306 && python manage.py makemigrations && python manage.py migrate && python manage.py loaddata incidents/fixtures/*.json && python manage.py collectstatic --no-input && python manage.py runserver 0.0.0.0:8000"
     container_name: fir
     hostname: fir
     depends_on:


### PR DESCRIPTION
While checking the docker-compose for https://github.com/certsocietegenerale/FIR/issues/293#issuecomment-1510824717 i realized migrations are not automatically made when starting docker.

This is not good since FIR does not include the last migrations in the repo (`two_factor` implementation, etc)