### PR TITLE
Added a missing context field for the fir_alerting module.

### DIFF
--- a/fir_alerting/views.py
+++ b/fir_alerting/views.py
@@ -86,6 +86,7 @@ def get_template(request, incident_id, template_type, bl=None, authorization_tar
         'phishing_url': i.subject.replace('http://', "hxxp://").replace('https://', 'hxxps://'),
         'artifacts': artifacts,
         'incident_id': i.id,
+	'severity': i.severity,
         'enrich': enrich
     })
 


### PR DESCRIPTION
The fir_alerting module was missing the "severity" field which forced analysts to re-enter it manually.

This new field will allow to add the severity field to the templates.