### PR TITLE
Fix a bug in "Close old incidents" button from quarterly dashboard

### DIFF
--- a/incidents/models.py
+++ b/incidents/models.py
@@ -196,7 +196,7 @@ class Incident(FIRModel, models.Model):
     def is_open(self):
         return self.get_last_action != "Closed"
 
-    def close_timeout(self):
+    def close_timeout(self, username='cert'):
         previous_status = self.status
         self.status = 'C'
         self.save()
@@ -207,7 +207,7 @@ class Incident(FIRModel, models.Model):
         c.date = datetime.datetime.now()
         c.action = Label.objects.get(name='Closed', group__name='action')
         c.incident = self
-        c.opened_by = User.objects.get(username='cert')
+        c.opened_by = User.objects.get(username= username)
         c.save()
 
     def get_last_comment(self):

--- a/incidents/views.py
+++ b/incidents/views.py
@@ -929,7 +929,7 @@ def close_old(request):
     old = Incident.authorization.for_user(request.user, 'incidents.handle_incidents').filter(query)
     for i in old:
         if i.status != "C":
-            i.close_timeout()
+            i.close_timeout(username = request.user.username)
 
     return redirect('stats:quarterly_bl_stats_default')
 


### PR DESCRIPTION
Update close timeout function : When someone hits the "Close old incidents" button from quarterly dashboard, an error triggers if the user "cert" doesn't exist. --> Update the function to attribute the closure comment to the user who clicked on the button instead of "cert" user.