### PR TITLE
Fix virustotal search link

### DIFF
--- a/fir_artifacts/static/fir_artifacts/js/tooltips.js
+++ b/fir_artifacts/static/fir_artifacts/js/tooltips.js
@@ -26,7 +26,7 @@ function virustotal_tooltip(hash) {
 	li = $('<li />')
 	li.text("Virustotal on ")
 	a = $('<a></a>')
-	a.attr("href","https://www.virustotal.com/en/search/?query="+hash)
+	a.attr("href","https://www.virustotal.com/gui/search/"+hash)
 	a.attr('target','_blank')
 	a.text(hash)
 	li.append(a)


### PR DESCRIPTION
VT link was broken : we need to search "https://www.virustotal.com/gui/search/<blablabla>" instead of "https://www.virustotal.com/en/search/?query=<blablabla>"