### PR TITLE
Remove `index_together` from  `fir_notifications` models

### DIFF
--- a/fir_notifications/migrations/0001_initial.py
+++ b/fir_notifications/migrations/0001_initial.py
@@ -44,12 +44,4 @@ class Migration(migrations.Migration):
                 'verbose_name_plural': 'notification templates',
             },
         ),
-        migrations.AlterUniqueTogether(
-            name='methodconfiguration',
-            unique_together=set([('user', 'key')]),
-        ),
-        migrations.AlterIndexTogether(
-            name='methodconfiguration',
-            index_together=set([('user', 'key')]),
-        ),
     ]

--- a/fir_notifications/migrations/0002_user_preference.py
+++ b/fir_notifications/migrations/0002_user_preference.py
@@ -29,12 +29,4 @@ class Migration(migrations.Migration):
                 'verbose_name_plural': 'notification preferences',
             },
         ),
-        migrations.AlterUniqueTogether(
-            name='notificationpreference',
-            unique_together=set([('user', 'event', 'method')]),
-        ),
-        migrations.AlterIndexTogether(
-            name='notificationpreference',
-            index_together=set([('user', 'event', 'method')]),
-        ),
     ]

--- a/fir_notifications/models.py
+++ b/fir_notifications/models.py
@@ -89,7 +89,7 @@ class MethodConfiguration(models.Model):
         verbose_name = _('method configuration')
         verbose_name_plural = _('method configurations')
         unique_together = (("user", "key"),)
-        index_together = ["user", "key"]
+        indexes = [models.Index(fields=["user", "key"])]
 
 
 class NotificationTemplate(models.Model):
@@ -120,5 +120,5 @@ class NotificationPreference(models.Model):
         verbose_name = _('notification preference')
         verbose_name_plural = _('notification preferences')
         unique_together = (("user", "event", "method"),)
-        index_together = ["user", "event", "method"]
+        indexes = [models.Index(fields=["user", "event", "method"])]
         ordering = ['user', 'event', 'method']


### PR DESCRIPTION
`index_together`  was removed in django5.

Fix https://github.com/certsocietegenerale/FIR/issues/327