### PR TITLE
`fir_api`: Allow to filter incidents using multiple categories / severities

### DIFF
--- a/fir_api/filters.py
+++ b/fir_api/filters.py
@@ -24,6 +24,7 @@ from incidents.models import (
     ValidAttribute,
     Comments,
     File,
+    SeverityChoice,
     STATUS_CHOICES,
     CONFIDENTIALITY_LEVEL,
 )
@@ -74,7 +75,11 @@ class IncidentFilter(FilterSet):
     """
 
     id = NumberFilter(field_name="id")
-    severity = NumberFilter(field_name="severity")
+    severity = ModelMultipleChoiceFilter(
+        to_field_name="name",
+        field_name="severity__name",
+        queryset=SeverityChoice.objects.all(),
+    )
     created_before = DateTimeFilter(field_name="date", lookup_expr="lte")
     created_after = DateTimeFilter(field_name="date", lookup_expr="gte")
     subject = CharFilter(field_name="subject", lookup_expr="icontains")
@@ -93,7 +98,7 @@ class IncidentFilter(FilterSet):
     concerned_business_lines = AllValuesMultipleFilterAllAllowed(
         field_name="concerned_business_lines__name", lookup_expr="icontains"
     )
-    category = ModelChoiceFilter(
+    category = ModelMultipleChoiceFilter(
         to_field_name="name",
         field_name="category__name",
         queryset=IncidentCategory.objects.all(),

--- a/fir_api/filters.py
+++ b/fir_api/filters.py
@@ -350,9 +350,7 @@ class StatsFilter(IncidentFilter):
     last_comment_date_before = None
     last_comment_date_after = None
 
-    aggregation = CharFilter(
-        method="aggregate_by", label=_("Aggregate by"), required=True
-    )
+    aggregation = CharFilter(method="aggregate_by", label=_("Aggregate by"))
 
     def aggregate_by(self, queryset, name, aggregate_by):
         valid_aggregations = [

--- a/fir_api/serializers.py
+++ b/fir_api/serializers.py
@@ -303,10 +303,9 @@ class IncidentCategoriesSerializer(serializers.ModelSerializer):
 
 class StatsSerializer(serializers.ModelSerializer):
     year = serializers.DateTimeField(required=False, format="%Y")
-    month = serializers.DateTimeField(required=False, format="%b")
-    week = serializers.DateTimeField(required=False, format="%V")
-    day = serializers.DateTimeField(required=False, format="%m-%d")
-    hour = serializers.DateTimeField(required=False, format="%m-%d %H:%M")
+    month = serializers.DateTimeField(required=False, format="%Y-%m")
+    day = serializers.DateTimeField(required=False, format="%Y-%m-%d")
+    hour = serializers.DateTimeField(required=False, format="%Y-%m-%d %H:%M")
     count = serializers.IntegerField(required=False)
     category = serializers.CharField(required=False, source="category__name")
     severity = serializers.CharField(required=False, source="severity__name")
@@ -321,7 +320,6 @@ class StatsSerializer(serializers.ModelSerializer):
         fields = [
             "year",
             "month",
-            "week",
             "day",
             "hour",
             "category",


### PR DESCRIPTION
In addition, fix various issues in the `/stats` endpoint:
- Remove aggregation by weeks
- Improve consistency across date formats .
- Fix a bug caused by by python optimization (cached properties cause a wrong aggregation to be applied when nesting the final object)
- Make aggregation parameter non-mandatory. When no aggregation is defined, a simple count of incidents is returned
