### PR TITLE
Add a boolean field "can edit" to the API incident endpoint

### DIFF
--- a/fir_api/serializers.py
+++ b/fir_api/serializers.py
@@ -202,6 +202,7 @@ class IncidentSerializer(serializers.ModelSerializer):
         style={"base_template": "textarea.html"}, required=False
     )
     last_comment_date = serializers.DateTimeField(read_only=True)
+    can_edit = serializers.SerializerMethodField()
 
     _additional_fields = {}
 
@@ -280,6 +281,15 @@ class IncidentSerializer(serializers.ModelSerializer):
                 field_serializer.save(incident=instance)
 
         return super().update(instance, validated_data)
+
+    def get_can_edit(self, obj):
+        try:
+            has_permission = Incident.authorization.for_user(
+                self._context["request"].user, "incidents.handle_incidents"
+            ).get(pk=obj.id)
+            return True
+        except Incident.DoesNotExist:
+            return False
 
 
 class ValidAttributeSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
return a boolean field, `can_edit`, when listing incidents. 
This will allow to display/hide edit buttons if it is decided to use the API for displaying incidents