### PR TITLE
`fir_artifacts_enrichment`: Use pypi instead of a git clone when downloading requirements

### DIFF
--- a/fir_artifacts_enrichment/requirements.txt
+++ b/fir_artifacts_enrichment/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/certsocietegenerale/abuse_finder.git#egg=abuse_finder
+abuse_finder>=0.3


### PR DESCRIPTION
Use pypi instead of a git clone for downloading the module `abuse_finder`