### PR TITLE
Standardize datetime format between the API and GUI

### DIFF
--- a/fir/config/base.py
+++ b/fir/config/base.py
@@ -18,11 +18,11 @@ LOGOUT_URL = "/logout/"
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.
 # In a Windows environment this must be set to your system time zone.
-TIME_ZONE = 'Europe/Paris'
+TIME_ZONE = "Europe/Paris"
 
 # Language code for this installation. All choices can be found here:
 # http://www.i18nguy.com/unicode/language-identifiers.html
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = "en-us"
 
 SITE_ID = 1
 
@@ -40,27 +40,27 @@ USE_TZ = False
 # URL that handles the media served from MEDIA_ROOT. Make sure to use a
 # trailing slash.
 # Examples: "http://media.lawrence.com/media/", "http://example.com/media/"
-MEDIA_URL = '/files/'
+MEDIA_URL = "/files/"
 
 # URL prefix for static files.
 # Example: "http://media.lawrence.com/static/"
-STATIC_URL = '/static/'
+STATIC_URL = "/static/"
 
 # List of finder classes that know how to find static files in
 # various locations.
 STATICFILES_FINDERS = (
-    'django.contrib.staticfiles.finders.FileSystemFinder',
-    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-#    'django.contrib.staticfiles.finders.DefaultStorageFinder',
+    "django.contrib.staticfiles.finders.FileSystemFinder",
+    "django.contrib.staticfiles.finders.AppDirectoriesFinder",
+    #    'django.contrib.staticfiles.finders.DefaultStorageFinder',
 )
 
 MIDDLEWARE = (
-    'django.middleware.common.CommonMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.locale.LocaleMiddleware'
+    "django.middleware.common.CommonMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.locale.LocaleMiddleware",
     # Uncomment the next line for simple clickjacking protection:
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
@@ -68,43 +68,43 @@ MIDDLEWARE = (
 
 # Authentication and authorization backends
 AUTHENTICATION_BACKENDS = (
-    'django.contrib.auth.backends.ModelBackend',  # default
-    'incidents.authorization.ObjectPermissionBackend',
+    "django.contrib.auth.backends.ModelBackend",  # default
+    "incidents.authorization.ObjectPermissionBackend",
 )
 
 # Absolute filesystem path to the directory that will hold user-uploaded files
-MEDIA_ROOT = os.path.join(BASE_DIR, 'uploads')
+MEDIA_ROOT = os.path.join(BASE_DIR, "uploads")
 
 # Absolute path to the directory static files should be collected to.
 # Don't put anything in this directory yourself; store your static files
 # in apps' "static/" subdirectories and in STATICFILES_DIRS.
-STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+STATIC_ROOT = os.path.join(BASE_DIR, "static")
 
-ROOT_URLCONF = 'fir.urls'
+ROOT_URLCONF = "fir.urls"
 
 # Python dotted path to the WSGI application used by Django's runserver.
-WSGI_APPLICATION = 'fir.wsgi.application'
+WSGI_APPLICATION = "fir.wsgi.application"
 
 INSTALLED_APPS = (
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.sites',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'django.contrib.admin',
-    'rest_framework',
-    'rest_framework.authtoken',
-    'django_filters',
-    'fir_plugins',
-    'incidents',
-    'fir_artifacts',
-    'treebeard',
-    'fir_email',
-    'colorfield'
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.sites",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "django.contrib.admin",
+    "rest_framework",
+    "rest_framework.authtoken",
+    "django_filters",
+    "fir_plugins",
+    "incidents",
+    "fir_artifacts",
+    "treebeard",
+    "fir_email",
+    "colorfield",
 )
 
-apps_file = os.path.join(BASE_DIR, 'fir', 'config', 'installed_apps.txt')
+apps_file = os.path.join(BASE_DIR, "fir", "config", "installed_apps.txt")
 if os.path.exists(apps_file):
     apps = list(INSTALLED_APPS)
     with open(apps_file) as f:
@@ -112,7 +112,7 @@ if os.path.exists(apps_file):
             line = line.strip()
             if line != "":
                 apps.append(line)
-                settings = '{}.settings'.format(line)
+                settings = "{}.settings".format(line)
                 if find_loader(settings):
                     globals().update(import_module(settings).__dict__)
 
@@ -121,23 +121,23 @@ if os.path.exists(apps_file):
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'OPTIONS': {
-            'context_processors': (
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "OPTIONS": {
+            "context_processors": (
                 "django.contrib.auth.context_processors.auth",
                 "django.template.context_processors.debug",
                 "django.template.context_processors.i18n",
                 "django.template.context_processors.media",
                 "django.template.context_processors.static",
                 "django.template.context_processors.request",
-                "django.contrib.messages.context_processors.messages"
+                "django.contrib.messages.context_processors.messages",
             )
-        }
+        },
     }
 ]
 
 # Permission added to the incident created by user, None for no permission
-INCIDENT_CREATOR_PERMISSION = 'incidents.view_incidents'
+INCIDENT_CREATOR_PERMISSION = "incidents.view_incidents"
 
 # If you can see an event/incident, you can comment it!
 INCIDENT_VIEWER_CAN_COMMENT = True
@@ -147,20 +147,30 @@ INCIDENT_VIEWER_CAN_COMMENT = True
 MARKDOWN_SAFE_MODE = True
 
 ALLOWED_HOSTS = ["127.0.0.1", "0.0.0.0", "localhost"]
-CSRF_TRUSTED_ORIGINS = ['http://' + h for h in ALLOWED_HOSTS] + ['https://' + h for h in ALLOWED_HOSTS]
+CSRF_TRUSTED_ORIGINS = ["http://" + h for h in ALLOWED_HOSTS] + [
+    "https://" + h for h in ALLOWED_HOSTS
+]
 
-if bool(strtobool(os.getenv('HTTPS', 'False'))):
+if bool(strtobool(os.getenv("HTTPS", "False"))):
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True
 
 # Allowed HTML tags in Markdown output (requires MARKDOWN_SAFE_MODE to be True)
 MARKDOWN_ALLOWED_TAGS = frozenset(bleach.sanitizer.ALLOWED_TAGS) | {
-    'p',
-    'h1', 'h2', 'h3', 'h4',
-    'table', 'thead', 'th', 'tbody', 'tr', 'td',
-    'br',
-    'hr',
-    'pre'
+    "p",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "table",
+    "thead",
+    "th",
+    "tbody",
+    "tr",
+    "td",
+    "br",
+    "hr",
+    "pre",
 }
 
 # Map of allowed attributes by HTML tag in Markdown output (requires MARKDOWN_SAFE_MODE to be True)
@@ -172,13 +182,13 @@ MARKDOWN_ALLOWED_PROTOCOLS = frozenset(bleach.sanitizer.ALLOWED_PROTOCOLS)
 # User self-service features
 USER_SELF_SERVICE = {
     # User can change his own email address
-    'CHANGE_EMAIL': True,
+    "CHANGE_EMAIL": True,
     # User can change his first and last name
-    'CHANGE_NAMES': True,
+    "CHANGE_NAMES": True,
     # User can change his profile values (number of incidents per page, hide closed incidents)
-    'CHANGE_PROFILE': True,
+    "CHANGE_PROFILE": True,
     # User can change his password
-    'CHANGE_PASSWORD': True
+    "CHANGE_PASSWORD": True,
 }
 
 # Put notification events you don't want in this tuple
@@ -192,26 +202,24 @@ NOTIFICATIONS_MERGE_INCIDENTS_AND_EVENTS = False
 INCIDENT_SHOW_ID = False
 
 # Incident ID prefix in views and links
-INCIDENT_ID_PREFIX = 'FIR-'
+INCIDENT_ID_PREFIX = "FIR-"
 
 REST_FRAMEWORK = {
-    'DEFAULT_PAGINATION_CLASS': 'fir_api.pagination.CustomPageNumberPagination',
-    'PAGE_SIZE': 25,
-
+    "DEFAULT_PAGINATION_CLASS": "fir_api.pagination.CustomPageNumberPagination",
+    "PAGE_SIZE": 25,
+    "DATETIME_INPUT_FORMATS": ["%Y-%m-%dT%H:%M"],
     # Any access to the API requires the user to be authenticated.
-    'DEFAULT_PERMISSION_CLASSES': ('rest_framework.permissions.IsAuthenticated',),
-
+    "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
     # If you prefer to use default TokenAuthentication using Basic Auth mechanism,
     # replace fir_api.authentication.TokenAuthentication with rest_framework.authentication.TokenAuthentication.
-    'DEFAULT_AUTHENTICATION_CLASSES': (
-        'fir_api.authentication.TokenAuthentication',
-        'rest_framework.authentication.SessionAuthentication'),
-
+    "DEFAULT_AUTHENTICATION_CLASSES": (
+        "fir_api.authentication.TokenAuthentication",
+        "rest_framework.authentication.SessionAuthentication",
+    ),
     # Following configuration is dedicated to fir_api.authentication.TokenAuthentication.
-    'TOKEN_AUTHENTICATION_KEYWORD': 'Token',
-
+    "TOKEN_AUTHENTICATION_KEYWORD": "Token",
     # HTTP_X_API == "X-Api" in HTTP headers.
-    'TOKEN_AUTHENTICATION_META': 'HTTP_X_API',
+    "TOKEN_AUTHENTICATION_META": "HTTP_X_API",
 }
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"

--- a/incidents/models.py
+++ b/incidents/models.py
@@ -37,10 +37,7 @@ CONFIDENTIALITY_LEVEL = (
     (3, "C3"),
 )
 
-LIGHT_MODE_CHOICES = (
-    ("light", "light"),
-    ("dark", "dark")
-)
+LIGHT_MODE_CHOICES = (("light", "light"), ("dark", "dark"))
 
 # Special Model class that handles signals
 
@@ -65,10 +62,12 @@ class Profile(models.Model):
     user = models.OneToOneField(User, on_delete=models.CASCADE)
     incident_number = models.IntegerField(default=50)
     hide_closed = models.BooleanField(default=False)
-    light_mode = models.CharField(max_length=10, choices=LIGHT_MODE_CHOICES, default="light")
+    light_mode = models.CharField(
+        max_length=10, choices=LIGHT_MODE_CHOICES, default="light"
+    )
 
     def __str__(self):
-        return u"Profile for user '{}'".format(self.user)
+        return "Profile for user '{}'".format(self.user)
 
 
 # Audit trail ================================================================
@@ -78,16 +77,25 @@ class Log(models.Model):
     who = models.ForeignKey(User, on_delete=models.CASCADE, null=True, blank=True)
     what = models.CharField(max_length=100, choices=STATUS_CHOICES)
     when = models.DateTimeField(auto_now_add=True)
-    incident = models.ForeignKey('Incident', on_delete=models.CASCADE, null=True, blank=True)
-    comment = models.ForeignKey('Comments', on_delete=models.CASCADE, null=True, blank=True)
+    incident = models.ForeignKey(
+        "Incident", on_delete=models.CASCADE, null=True, blank=True
+    )
+    comment = models.ForeignKey(
+        "Comments", on_delete=models.CASCADE, null=True, blank=True
+    )
 
     def __str__(self):
         if self.incident:
-            return u"[%s] %s %s (%s)" % (self.when, self.what, self.incident, self.who)
+            return "[%s] %s %s (%s)" % (self.when, self.what, self.incident, self.who)
         elif self.comment:
-            return u"[%s] %s comment on %s (%s)" % (self.when, self.what, self.comment.incident, self.who)
+            return "[%s] %s comment on %s (%s)" % (
+                self.when,
+                self.what,
+                self.comment.incident,
+                self.who,
+            )
         else:
-            return u"[%s] %s (%s)" % (self.when, self.what, self.who)
+            return "[%s] %s (%s)" % (self.when, self.what, self.who)
 
 
 class LabelGroup(models.Model):
@@ -111,43 +119,62 @@ class BusinessLine(MP_Node, AuthorizationModelMixin):
     def __str__(self):
         parents = list(self.get_ancestors())
         parents.append(self)
-        return u" > ".join([bl.name for bl in parents])
+        return " > ".join([bl.name for bl in parents])
 
     class Meta:
-        verbose_name = _('business line')
+        verbose_name = _("business line")
 
     def get_incident_count(self, query):
         incident_count = self.incident_set.filter(query).distinct().count()
-        incident_count += Incident.objects.filter(query).filter(
-            concerned_business_lines__in=self.get_descendants()).distinct().count()
+        incident_count += (
+            Incident.objects.filter(query)
+            .filter(concerned_business_lines__in=self.get_descendants())
+            .distinct()
+            .count()
+        )
         return incident_count
 
 
 class AccessControlEntry(models.Model):
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, verbose_name=_('user'))
-    business_line = models.ForeignKey(BusinessLine, on_delete=models.CASCADE, verbose_name=_('business line'), related_name='acl')
-    role = models.ForeignKey('auth.Group', on_delete=models.CASCADE, verbose_name=_('role'))
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.CASCADE, verbose_name=_("user")
+    )
+    business_line = models.ForeignKey(
+        BusinessLine,
+        on_delete=models.CASCADE,
+        verbose_name=_("business line"),
+        related_name="acl",
+    )
+    role = models.ForeignKey(
+        "auth.Group", on_delete=models.CASCADE, verbose_name=_("role")
+    )
 
     def __str__(self):
         return _("{} is {} on {}").format(self.user, self.role, self.business_line)
 
     class Meta:
-        verbose_name = _('access control entry')
-        verbose_name_plural = _('access control entries')
+        verbose_name = _("access control entry")
+        verbose_name_plural = _("access control entries")
 
 
 class BaleCategory(models.Model):
     name = models.CharField(max_length=200)
     description = models.TextField(blank=True, null=True)
     category_number = models.IntegerField()
-    parent_category = models.ForeignKey('BaleCategory', on_delete=models.CASCADE, null=True, blank=True)
+    parent_category = models.ForeignKey(
+        "BaleCategory", on_delete=models.CASCADE, null=True, blank=True
+    )
 
     class Meta:
         verbose_name_plural = "Bale categories"
 
     def __str__(self):
         if self.parent_category:
-            return "(%s > %s) %s" % (self.parent_category.category_number, self.category_number, self.name)
+            return "(%s > %s) %s" % (
+                self.parent_category.category_number,
+                self.category_number,
+                self.name,
+            )
         else:
             return "(%s) %s" % (self.category_number, self.name)
 
@@ -166,30 +193,59 @@ class IncidentCategory(models.Model):
 
 # Core models ================================================================
 
-@tree_authorization(fields=['concerned_business_lines', ], tree_model='incidents.BusinessLine',
-                    owner_field='opened_by', owner_permission=settings.INCIDENT_CREATOR_PERMISSION)
+
+@tree_authorization(
+    fields=[
+        "concerned_business_lines",
+    ],
+    tree_model="incidents.BusinessLine",
+    owner_field="opened_by",
+    owner_permission=settings.INCIDENT_CREATOR_PERMISSION,
+)
 @link_to(File)
 @link_to(Artifact)
 class Incident(FIRModel, models.Model):
-    date = models.DateTimeField(default=datetime.datetime.now, blank=True)
+    date = models.DateTimeField(
+        default=datetime.datetime.now().replace(second=0, microsecond=0), blank=True
+    )
     is_starred = models.BooleanField(default=False)
     subject = models.CharField(max_length=256)
     description = models.TextField()
     category = models.ForeignKey(IncidentCategory, on_delete=models.CASCADE)
     concerned_business_lines = models.ManyToManyField(BusinessLine, blank=True)
-    main_business_lines = models.ManyToManyField(BusinessLine, related_name='incidents_affecting_main', blank=True)
-    detection = models.ForeignKey(Label, on_delete=models.CASCADE, limit_choices_to={'group__name': 'detection'}, related_name='detection_label')
+    main_business_lines = models.ManyToManyField(
+        BusinessLine, related_name="incidents_affecting_main", blank=True
+    )
+    detection = models.ForeignKey(
+        Label,
+        on_delete=models.CASCADE,
+        limit_choices_to={"group__name": "detection"},
+        related_name="detection_label",
+    )
     severity = models.ForeignKey(
-        'SeverityChoice', null=True, blank=True, on_delete=models.SET_NULL)
+        "SeverityChoice", null=True, blank=True, on_delete=models.SET_NULL
+    )
     is_incident = models.BooleanField(default=False)
     is_major = models.BooleanField(default=False)
-    actor = models.ForeignKey(Label, on_delete=models.CASCADE, limit_choices_to={'group__name': 'actor'}, related_name='actor_label', blank=True,
-                              null=True)
-    plan = models.ForeignKey(Label, on_delete=models.CASCADE, limit_choices_to={'group__name': 'plan'}, related_name='plan_label', blank=True,
-                             null=True)
+    actor = models.ForeignKey(
+        Label,
+        on_delete=models.CASCADE,
+        limit_choices_to={"group__name": "actor"},
+        related_name="actor_label",
+        blank=True,
+        null=True,
+    )
+    plan = models.ForeignKey(
+        Label,
+        on_delete=models.CASCADE,
+        limit_choices_to={"group__name": "plan"},
+        related_name="plan_label",
+        blank=True,
+        null=True,
+    )
     status = models.CharField(max_length=20, choices=STATUS_CHOICES, default=_("Open"))
     opened_by = models.ForeignKey(User, on_delete=models.CASCADE)
-    confidentiality = models.IntegerField(choices=CONFIDENTIALITY_LEVEL, default='1')
+    confidentiality = models.IntegerField(choices=CONFIDENTIALITY_LEVEL, default="1")
 
     def __str__(self):
         return self.subject
@@ -197,25 +253,27 @@ class Incident(FIRModel, models.Model):
     def is_open(self):
         return self.get_last_action != "Closed"
 
-    def close_timeout(self, username='cert'):
+    def close_timeout(self, username="cert"):
         previous_status = self.status
-        self.status = 'C'
+        self.status = "C"
         self.save()
-        model_status_changed.send(sender=Incident, instance=self, previous_status=previous_status)
+        model_status_changed.send(
+            sender=Incident, instance=self, previous_status=previous_status
+        )
 
         c = Comments()
         c.comment = "Incident closed (timeout)"
         c.date = datetime.datetime.now()
-        c.action = Label.objects.get(name='Closed', group__name='action')
+        c.action = Label.objects.get(name="Closed", group__name="action")
         c.incident = self
-        c.opened_by = User.objects.get(username= username)
+        c.opened_by = User.objects.get(username=username)
         c.save()
 
     def get_last_comment(self):
-        return self.comments_set.order_by('-date')[0]
+        return self.comments_set.order_by("-date")[0]
 
     def get_last_action(self):
-        c = self.comments_set.order_by('-date')[0]
+        c = self.comments_set.order_by("-date")[0]
 
         action = "%s (%s)" % (c.action, c.date.strftime("%Y %d %b %H:%M:%S"))
 
@@ -275,32 +333,41 @@ class Incident(FIRModel, models.Model):
 
     class Meta:
         permissions = (
-            ('handle_incidents', 'Can handle incidents'),
-            ('report_events', 'Can report events'),
-            ('view_incidents', 'Can view incidents'),
-            ('view_statistics', 'Can view statistics'),
+            ("handle_incidents", "Can handle incidents"),
+            ("report_events", "Can report events"),
+            ("view_incidents", "Can view incidents"),
+            ("view_statistics", "Can view statistics"),
         )
 
 
 class Comments(models.Model):
     date = models.DateTimeField(default=datetime.datetime.now, blank=True)
     comment = models.TextField()
-    action = models.ForeignKey(Label, on_delete=models.CASCADE, limit_choices_to={'group__name': 'action'}, related_name='action_label')
+    action = models.ForeignKey(
+        Label,
+        on_delete=models.CASCADE,
+        limit_choices_to={"group__name": "action"},
+        related_name="action_label",
+    )
     incident = models.ForeignKey(Incident, on_delete=models.CASCADE)
     opened_by = models.ForeignKey(User, on_delete=models.CASCADE)
 
     class Meta:
-        verbose_name_plural = 'comments'
+        verbose_name_plural = "comments"
 
     def __str__(self):
-        return u"Comment for incident %s" % self.incident.id
+        return "Comment for incident %s" % self.incident.id
 
     @classmethod
     def create_diff_comment(cls, incident, data, user):
-        comments = ''
+        comments = ""
         for key in data:
             # skip the following fields from diff
-            if key in ['description', 'concerned_business_lines', 'main_business_lines']:
+            if key in [
+                "description",
+                "concerned_business_lines",
+                "main_business_lines",
+            ]:
                 continue
 
             new = data[key]
@@ -309,36 +376,36 @@ class Comments(models.Model):
             if new != old:
                 label = key
 
-                if key == 'is_major':
-                    label = 'major'
-                if key == 'concerned_business_lines':
+                if key == "is_major":
+                    label = "major"
+                if key == "concerned_business_lines":
                     label = "business lines"
-                if key == 'main_business_line':
+                if key == "main_business_line":
                     label = "main business line"
-                if key == 'is_incident':
-                    label = 'incident'
+                if key == "is_incident":
+                    label = "incident"
 
                 if old == "O":
-                    old = 'Open'
+                    old = "Open"
                 if old == "C":
-                    old = 'Closed'
+                    old = "Closed"
                 if old == "B":
-                    old = 'Blocked'
+                    old = "Blocked"
                 if new == "O":
-                    new = 'Open'
+                    new = "Open"
                 if new == "C":
-                    new = 'Closed'
+                    new = "Closed"
                 if new == "B":
-                    new = 'Blocked'
+                    new = "Blocked"
 
-                comments += u'Changed "%s" from "%s" to "%s"; ' % (label, old, new)
+                comments += 'Changed "%s" from "%s" to "%s"; ' % (label, old, new)
 
         if comments:
             Comments.objects.create(
                 comment=comments,
-                action=Label.objects.get(name='Info'),
+                action=Label.objects.get(name="Info"),
                 incident=incident,
-                opened_by=user
+                opened_by=user,
             )
 
 
@@ -363,7 +430,7 @@ class ValidAttribute(models.Model):
 
 class SeverityChoice(models.Model):
     name = models.CharField(max_length=50)
-    color = ColorField(default='#777')
+    color = ColorField(default="#777")
 
     def __str__(self):
         return self.name
@@ -371,18 +438,42 @@ class SeverityChoice(models.Model):
 
 # Templating =================================================================
 
+
 class IncidentTemplate(models.Model):
     name = models.CharField(max_length=100)
     subject = models.CharField(max_length=256, null=True, blank=True)
     description = models.TextField(null=True, blank=True)
-    category = models.ForeignKey(IncidentCategory, on_delete=models.CASCADE, null=True, blank=True)
+    category = models.ForeignKey(
+        IncidentCategory, on_delete=models.CASCADE, null=True, blank=True
+    )
     concerned_business_lines = models.ManyToManyField(BusinessLine, blank=True)
-    detection = models.ForeignKey(Label, on_delete=models.CASCADE, limit_choices_to={'group__name': 'detection'}, null=True, blank=True)
+    detection = models.ForeignKey(
+        Label,
+        on_delete=models.CASCADE,
+        limit_choices_to={"group__name": "detection"},
+        null=True,
+        blank=True,
+    )
     severity = models.ForeignKey(
-        'SeverityChoice', null=True, blank=True, on_delete=models.SET_NULL)
+        "SeverityChoice", null=True, blank=True, on_delete=models.SET_NULL
+    )
     is_incident = models.BooleanField(default=False)
-    actor = models.ForeignKey(Label, on_delete=models.CASCADE, limit_choices_to={'group__name': 'actor'}, related_name='+', blank=True, null=True)
-    plan = models.ForeignKey(Label, on_delete=models.CASCADE, limit_choices_to={'group__name': 'plan'}, related_name='+', blank=True, null=True)
+    actor = models.ForeignKey(
+        Label,
+        on_delete=models.CASCADE,
+        limit_choices_to={"group__name": "actor"},
+        related_name="+",
+        blank=True,
+        null=True,
+    )
+    plan = models.ForeignKey(
+        Label,
+        on_delete=models.CASCADE,
+        limit_choices_to={"group__name": "plan"},
+        related_name="+",
+        blank=True,
+        null=True,
+    )
 
     def __str__(self):
         return self.name
@@ -406,8 +497,8 @@ def refresh_incident(sender, instance, **kwargs):
 def comment_new_incident(sender, instance, created, **kwargs):
     if created:
         Comments.objects.create(
-            comment='Incident opened',
-            action=Label.objects.get(name='Opened'),
+            comment="Incident opened",
+            action=Label.objects.get(name="Opened"),
             incident=instance,
             opened_by=instance.opened_by,
             date=instance.date,
@@ -420,8 +511,8 @@ def comment_new_incident(sender, instance, created, **kwargs):
 @receiver(post_save, sender=Incident)
 def log_new_incident(sender, instance, created, **kwargs):
     if created:
-        what = 'Created incident'
+        what = "Created incident"
     else:
-        what = 'Edit incident'
+        what = "Edit incident"
 
     Log.objects.create(who=instance.opened_by, what=what, incident=instance)


### PR DESCRIPTION
Force datetime to be `%Y-%m-%dT%H:%M`, and change `datetime.datetime.now()` to `datetime.datetime.now().replace(second=0, microsecond=0)` to standardize datetime display accross FIR

 Also, apply `python black` to modified files.