### PR TITLE
Allow incident sorting by detection, opened_by

### DIFF
--- a/fir_api/views.py
+++ b/fir_api/views.py
@@ -120,6 +120,8 @@ class IncidentViewSet(
         "severity",
         "confidentiality",
         "actor",
+        "detection",
+        "opened_by",
     ]
     filterset_class = IncidentFilter
 


### PR DESCRIPTION
This PR allow sorting incidents by Detection or by user who opened the incident.
