### PR TITLE
Don't reject valid but wrongly formated datetime in order to not break existing scripts

### DIFF
--- a/fir/config/base.py
+++ b/fir/config/base.py
@@ -207,7 +207,8 @@ INCIDENT_ID_PREFIX = "FIR-"
 REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "fir_api.pagination.CustomPageNumberPagination",
     "PAGE_SIZE": 25,
-    "DATETIME_INPUT_FORMATS": ["%Y-%m-%dT%H:%M"],
+    "DATETIME_INPUT_FORMATS": ["%Y-%m-%dT%H:%M", "%Y-%m-%dT%H:%M:%S.%f", "%Y-%m-%dT%H:%M:%S"],
+    "DATETIME_FORMAT": "%Y-%m-%dT%H:%M",
     # Any access to the API requires the user to be authenticated.
     "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
     # If you prefer to use default TokenAuthentication using Basic Auth mechanism,


### PR DESCRIPTION
 https://github.com/certsocietegenerale/FIR/pull/347 is a breaking change, which could cause existing scripts to crash.

This PR proposes a more gentle approach while still standardizing how datetimes are displayed across FIR