### PR TITLE
Implementing drf_spectacular to make API compatible with OpenAPI standards.

### DIFF
--- a/fir/config/base.py
+++ b/fir/config/base.py
@@ -95,6 +95,8 @@ INSTALLED_APPS = (
     "django.contrib.admin",
     "rest_framework",
     "rest_framework.authtoken",
+    "drf_spectacular",
+    "drf_spectacular_sidecar",
     "django_filters",
     "fir_plugins",
     "incidents",
@@ -221,6 +223,19 @@ REST_FRAMEWORK = {
     "TOKEN_AUTHENTICATION_KEYWORD": "Token",
     # HTTP_X_API == "X-Api" in HTTP headers.
     "TOKEN_AUTHENTICATION_META": "HTTP_X_API",
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'FIR API',
+    'DESCRIPTION': 'Fast Incident Response OpenAPI specification',
+    'VERSION': '0.0.1',
+    'SERVE_INCLUDE_SCHEMA': True,
+    # OTHER SETTINGS
+    'SWAGGER_UI_DIST': 'SIDECAR',  # shorthand to use the sidecar instead
+    'SWAGGER_UI_FAVICON_HREF': 'SIDECAR',
+    'REDOC_DIST': 'SIDECAR',
+}
+

--- a/fir/config/base.py
+++ b/fir/config/base.py
@@ -229,13 +229,13 @@ REST_FRAMEWORK = {
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 SPECTACULAR_SETTINGS = {
-    'TITLE': 'FIR API',
-    'DESCRIPTION': 'Fast Incident Response OpenAPI specification',
-    'VERSION': '0.0.1',
-    'SERVE_INCLUDE_SCHEMA': True,
+    "TITLE": "FIR API",
+    "DESCRIPTION": "Fast Incident Response OpenAPI specification",
+    "VERSION": "0.0.1",
+    "SERVE_INCLUDE_SCHEMA": True,
     # OTHER SETTINGS
-    'SWAGGER_UI_DIST': 'SIDECAR',  # shorthand to use the sidecar instead
-    'SWAGGER_UI_FAVICON_HREF': 'SIDECAR',
-    'REDOC_DIST': 'SIDECAR',
+    "SWAGGER_UI_DIST": "SIDECAR",  # shorthand to use the sidecar instead
+    "SWAGGER_UI_FAVICON_HREF": "SIDECAR",
+    "REDOC_DIST": "SIDECAR",
 }
 

--- a/fir_api/serializers.py
+++ b/fir_api/serializers.py
@@ -228,18 +228,24 @@ class IncidentSerializer(serializers.ModelSerializer):
                     continue
 
                 for field in h.hooks.get("incident_fields", []):
-                    if field[2] is not None and (
-                        not field[0].endswith("_set")
-                        or kwargs["context"]["view"].action == "retrieve"
-                    ):
-                        instance._declared_fields.update({field[0]: field[2]})
-                        instance._additional_fields.update({field[0]: field[2]})
+                    try:
+                        if field[2] is not None and (
+                            not field[0].endswith("_set")
+                            or kwargs["context"]["view"].action == "retrieve"
+                        ):
+                            instance._declared_fields.update({field[0]: field[2]})
+                            instance._additional_fields.update({field[0]: field[2]})
+                    except KeyError as e:
+                        continue
 
-        if kwargs["context"]["view"].action != "retrieve":
-            del instance.fields["artifacts"]
-            del instance.fields["comments_set"]
-            del instance.fields["file_set"]
-            del instance.fields["attribute_set"]
+        try:
+            if kwargs["context"]["view"].action != "retrieve":
+                del instance.fields["artifacts"]
+                del instance.fields["comments_set"]
+                del instance.fields["file_set"]
+                del instance.fields["attribute_set"]
+        except KeyError as e:
+            pass
 
         return instance
 
@@ -283,7 +289,7 @@ class IncidentSerializer(serializers.ModelSerializer):
                 field_serializer.save(incident=instance)
 
         return super().update(instance, validated_data)
-
+    
     def get_can_edit(self, obj):
         try:
             has_permission = Incident.authorization.for_user(

--- a/fir_api/urls.py
+++ b/fir_api/urls.py
@@ -7,6 +7,7 @@ from django.utils.translation import gettext_lazy as _
 
 from fir_api import views
 from fir.config.base import INSTALLED_APPS
+from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 
 app_name = "fir_api"
 
@@ -30,6 +31,7 @@ router.register(r"severities", views.SeverityViewSet, basename="severities")
 router.register(r"categories", views.CategoryViewSet, basename="categories")
 router.register(r"stats", views.StatsViewSet, basename="stats")
 
+
 # Load plugin API URLs
 for app in INSTALLED_APPS:
     if app.startswith("fir_"):
@@ -46,4 +48,8 @@ for app in INSTALLED_APPS:
 urlpatterns = [
     re_path(r"^", include(router.urls)),
     re_path(r"^token/", token_views.obtain_auth_token),
-]
+    re_path(r"^schema/$", SpectacularAPIView.as_view(), name="schema"),
+    re_path(r"^schema/swagger-ui/$", SpectacularSwaggerView.as_view(url_name="fir_api:schema"), name="swagger-ui"),
+    re_path(r"^schema/redoc/$", SpectacularRedocView.as_view(url_name="fir_api:schema"), name="redoc"),
+
+    ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ markdown2
 bleach
 django-querysetsequence
 django-colorfield
+drf-spectacular
+drf-spectacular[sidecar]


### PR DESCRIPTION
To facilitate integration with certain automation tools and facilitate documentation for the developer, I imported the `drf_spectacular` library into FIR to generate a yaml file which is compatible with OpenAPI standards.
This also enables FIR to automatically create a Swagger_UI and Redoc webpage for the API documentation.

Commits : 
- Added try/except in serializers.py that prevented drf_spectacular from working.
- Imported the drf_spectacular module into fir/config/base.py
- Used drf_spectacular[sidecar] dependency to avoid relying on an external CDN.
 