### PR TITLE
`fir_api`: Implement stats per basel categories

### DIFF
--- a/fir_api/filters.py
+++ b/fir_api/filters.py
@@ -392,6 +392,7 @@ class StatsFilter(IncidentFilter):
             "detection",
             "actor",
             "date",
+            "baselcategory",
         ]
 
         for elem in aggregate_by.split(","):

--- a/fir_api/views.py
+++ b/fir_api/views.py
@@ -609,7 +609,11 @@ class StatsViewSet(ListModelMixin, viewsets.GenericViewSet):
                 .values("count")
             )
             values.append("count")
-            queryset = queryset.annotate(count=attr_subquery).filter(count__isnull=False).values(*values)
+            queryset = (
+                queryset.annotate(count=attr_subquery)
+                .filter(count__isnull=False)
+                .values(*values)
+            )
 
             # Remove attribute filter as it was already applied
             self.request.query_params._mutable = True
@@ -631,6 +635,12 @@ class StatsViewSet(ListModelMixin, viewsets.GenericViewSet):
                     "concerned_business_lines", queryset, values
                 )
                 applied_aggregations.append(agg)
+            elif agg == "baselcategory":
+                queryset, values = self.split_by_foreignkey_name(
+                    "category__bale_subcategory", queryset, values
+                )
+                applied_aggregations.append(agg)
+
         if return_applied_aggregations:
             return queryset, applied_aggregations
         else:


### PR DESCRIPTION
Add a new aggregation `baselcategory`, to aggregate incidents based on Basel Categories.

In addition, re-apply SQL optimizations removed in https://github.com/certsocietegenerale/FIR/pull/350 