### PR TITLE
Incidents search: Display errors when a search query is malformatted

### DIFF
--- a/incidents/static/custom_js/incident_display.js
+++ b/incidents/static/custom_js/incident_display.js
@@ -232,8 +232,13 @@ async function toggle_star(target) {
 
 async function refresh_display(div) {
   const loading = div.querySelector(".loading");
+  const error_p = div.querySelector(".error_message");
+
   if (loading) {
     loading.classList.remove("d-none");
+  }
+  if (error_p) {
+    error_p.textContent = "";
   }
   var url = div.dataset.url;
   var request = await fetch(url, {
@@ -242,6 +247,16 @@ async function refresh_display(div) {
   var response = await request.json();
   if (request.status != 200) {
     console.error(response);
+    if (loading) {
+      loading.classList.add("d-none");
+    }
+    if (error_p) {
+      if ("detail" in response) {
+        error_p.textContent = response["detail"];
+      } else {
+        error_p.textContent = response;
+      }
+    }
     return;
   }
 

--- a/incidents/templates/events/index-all.html
+++ b/incidents/templates/events/index-all.html
@@ -44,12 +44,13 @@
 {% else %}
   <div id="all_incidents" class="incident_display" data-url="/api/incidents?is_incident=false">
 {% endif %}
-  {% trans "Loading ..." %}
+  <div class="loading">{% trans "Loading ..." %}</div>
   {% if incident_view %}
     <p class="nothing_to_show d-none">{% trans "No incident found." %}</p>
   {% else %}
     <p class="nothing_to_show d-none">{% trans "No event found." %}</p>
   {% endif %}
+  <p class="error_message"></p>
   </div>
 {% csrf_token %}
 {% endblock %}


### PR DESCRIPTION
Errors are currently being printed in the javascript console, but are not displayed as text in the GUI. 