### PR TITLE
Use API when downloading/uploading attachments

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,7 +31,7 @@ RUN apk add libxml2 libxslt mariadb-connector-c libmagic openldap-dev gettext &&
     wget -O /bin/wait-for https://raw.githubusercontent.com/eficode/wait-for/master/wait-for && \
     chmod +x /bin/wait-for && \
     adduser -DH fir && \
-    mkdir -p /var/www/static && \
+    mkdir -p /var/www/static /app/uploads && \
     chown -R fir:fir /app/ /var/www/static
 
 WORKDIR /app/

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,6 +4,7 @@ networks:
 volumes:
   static-content:
   mariadb-data:
+  uploads:
 
 services:
   fir:
@@ -25,7 +26,7 @@ services:
     expose:
       - 8000
     volumes:
-      - /tmp/uploads:/app/uploads
+      - uploads:/app/uploads
       - static-content:/var/www/static
 
   fir_db:

--- a/fir_artifacts/files.py
+++ b/fir_artifacts/files.py
@@ -4,34 +4,16 @@ import zipfile
 from io import BytesIO
 
 from django.conf import settings
-from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import PermissionDenied
-from django.http import HttpResponse, Http404, HttpResponseRedirect
+from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
 from django.core.files import File as FileWrapper
 
+from incidents.models import Incident
 from fir_artifacts import Hash
 from fir_artifacts.models import File, Artifact
 
 
-def do_upload_file(request, content_type, object_id):
-
-    if request.method == 'POST':
-        object_type = ContentType.objects.get(pk=content_type)
-        obj = get_object_or_404(object_type.model_class(), pk=object_id)
-        if not request.user.has_perm('incidents.handle_incidents', obj=obj):
-            raise PermissionDenied()
-        descriptions = request.POST.getlist('description')
-        files = request.FILES.getlist('file')
-        if len(descriptions) == len(files):  # consider this as a valid upload form?
-            for i, file in enumerate(files):
-                handle_uploaded_file(file, descriptions[i], obj)
-
-    return HttpResponseRedirect(request.META.get('HTTP_REFERER'))
-
-
 def handle_uploaded_file(file, description, obj):
-
     f = File()
     f.description = description
     f.file = file
@@ -52,32 +34,23 @@ def handle_uploaded_file(file, description, obj):
         a.relations.add(obj)
         f.hashes.add(a)
     f.save()
-
     return f
 
 
 def do_download(request, file_id):
     f = get_object_or_404(File, pk=file_id)
-    if not request.user.has_perm('incidents.view_incidents', obj=f.get_related()):
-        raise PermissionDenied()
     wrapper = FileWrapper(f.file)
     content_type = mimetypes.guess_type(f.file.name)
     response = HttpResponse(wrapper, content_type=content_type)
-    response['Content-Disposition'] = 'attachment; filename=%s' % (f.getfilename())
-    response['Content-Length'] = os.path.getsize(str(f.file.file))
-
+    response["Content-Disposition"] = "attachment; filename=%s" % (f.getfilename())
+    response["Content-Length"] = os.path.getsize(str(f.file.file))
     return response
 
 
-def do_download_archive(request, content_type, object_id):
-    object_type = ContentType.objects.get(pk=content_type)
-    obj = get_object_or_404(object_type.model_class(), pk=object_id)
-    if not request.user.has_perm('incidents.view_incidents', obj=obj):
-        raise PermissionDenied()
-    if obj.file_set.count() == 0:
-        raise Http404
+def do_download_archive(request, object_id):
+    obj = get_object_or_404(Incident, pk=object_id)
     temp = BytesIO()
-    with zipfile.ZipFile(temp, 'w', zipfile.ZIP_DEFLATED) as archive:
+    with zipfile.ZipFile(temp, "w", zipfile.ZIP_DEFLATED) as archive:
         media_root = settings.MEDIA_ROOT
         for file in obj.file_set.all():
             path = os.path.join(media_root, file.file.path)
@@ -86,17 +59,9 @@ def do_download_archive(request, content_type, object_id):
     temp.seek(0)
     wrapper = FileWrapper(temp)
 
-    response = HttpResponse(wrapper, content_type='application/zip')
-    response['Content-Disposition'] = 'attachment; filename=archive_%s_%s.zip' % (object_type.model, object_id)
-    response['Content-Length'] = file_size
+    response = HttpResponse(wrapper, content_type="application/zip")
+    response["Content-Disposition"] = "attachment; filename=archive_incident_%s.zip" % (
+        object_id,
+    )
+    response["Content-Length"] = file_size
     return response
-
-
-def do_remove_file(request, file_id):
-    if request.method == "POST":
-        f = get_object_or_404(File, pk=file_id)
-        if not request.user.has_perm('incidents.handle_incidents', obj=f.get_related()):
-            raise PermissionDenied()
-        f.file.delete()
-        f.delete()
-    return HttpResponseRedirect(request.META.get('HTTP_REFERER'))

--- a/fir_artifacts/models.py
+++ b/fir_artifacts/models.py
@@ -29,7 +29,7 @@ def upload_path(instance, filename):
 
 class File(OneLinkableModel):
 
-    hashes = models.ManyToManyField('fir_artifacts.Artifact', blank=True)
+    hashes = models.ManyToManyField("fir_artifacts.Artifact", blank=True)
     description = models.CharField(max_length=256)
     file = models.FileField(upload_to=upload_path)
     date = models.DateTimeField(auto_now_add=True)
@@ -41,7 +41,7 @@ class File(OneLinkableModel):
         return os.path.basename(self.file.name)
 
     def get_hashes(self):
-        hashes = dict((k, None) for k in ['md5', 'sha1', 'sha256'])
+        hashes = dict((k, None) for k in ["md5", "sha1", "sha256"])
         content = self.file.read()
         for algo in hashes:
             m = hashlib.new(algo)

--- a/fir_artifacts/static/fir_artifacts/js/tooltips.js
+++ b/fir_artifacts/static/fir_artifacts/js/tooltips.js
@@ -1,82 +1,97 @@
 function centralops_tooltip(ip) {
-	d = $('<div />')
-	ul = $('<ul />')
+  const d = document.createElement("div");
+  const ul = document.createElement("ul");
+  const li = document.createElement("li");
+  const a = document.createElement("a");
 
-	li = $('<li />')
-	li.text("Centralops on ")
-	a = $('<a></a>')
-	a.attr("href","http://centralops.net/co/DomainDossier.aspx?addr="+ip+"&dom_whois=1&net_whois=1&dom_dns=1")
-	a.attr('target','_blank')
-	a.text(ip)
-	li.append(a)
+  li.textContent = "Centralops on ";
+  a.href =
+    "http://centralops.net/co/DomainDossier.aspx?addr=" +
+    encodeURIComponent(ip) +
+    "&dom_whois=1&net_whois=1&dom_dns=1";
+  a.target = "_blank";
+  a.textContent = ip;
 
-	ul.append(li)
-
-	d.append(ul)
-
-	return d.html()
+  li.appendChild(a);
+  ul.appendChild(li);
+  d.appendChild(ul);
+  return d.outerHTML;
 }
 
 function virustotal_tooltip(hash) {
-	// https://www.virustotal.com/en/search/?query=
+  const d = document.createElement("div");
+  const ul = document.createElement("ul");
+  const li = document.createElement("li");
+  const a = document.createElement("a");
 
-	d = $('<div />')
-	ul = $('<ul />')
+  li.textContent = "Virustotal on ";
+  a.href = "https://www.virustotal.com/gui/search/" + encodeURIComponent(hash);
+  a.target = "_blank";
+  a.textContent = hash;
 
-	li = $('<li />')
-	li.text("Virustotal on ")
-	a = $('<a></a>')
-	a.attr("href","https://www.virustotal.com/gui/search/"+hash)
-	a.attr('target','_blank')
-	a.text(hash)
-	li.append(a)
-
-	ul.append(li)
-
-	d.append(ul)
-
-	return d.html()
-
+  li.appendChild(a);
+  ul.appendChild(li);
+  d.appendChild(ul);
+  return d.outerHTML;
 }
 
-function find_hostnames(node) {
-	$(node).each(function(){
-		pattern = /((([\w\-]+\.)+)([a-zA-Z]{2,6}))(?!([^<]+)?>)/ig
-		$(this).html($(this).html().replace(pattern,'<span data-bs-toggle="tooltip" data-bs-html="true" data-bs-delay="500" title class="hostname">\$1</span>'))
-	})
+function find_hostnames(nodes) {
+  for (n of document.querySelectorAll(nodes)) {
+    const pattern = /((([\w\-]+\.)+)([a-zA-Z]{2,6}))(?!([^<]+)?>)/gi;
+    const replace =
+      '<span data-bs-toggle="tooltip" data-bs-html="true" data-bs-delay="500" title class="hostname">\$1</span>';
+    n.innerHTML = n.innerHTML.replace(pattern, replace);
+  }
 
-	$('span.hostname').each(function(){
-		$(this).attr('data-bs-original-title', centralops_tooltip($(this).text()))
-	})
+  for (const span of document.querySelectorAll("span.hostname")) {
+    span.setAttribute(
+      "data-bs-original-title",
+      centralops_tooltip(span.textContent),
+    );
+  }
 }
 
-function find_ips(node) {
-	$(node).each(function(){
-		pattern = /((((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))|(((([0-9a-fA-F]){1,4}):){1,4}:(((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])))|(::(ffff(:0{1,4}){0,1}:){0,1}(((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])))|(fe80:(:(([0-9a-fA-F]){1,4})){0,4}%[0-9a-zA-Z]{1,})|(:((:(([0-9a-fA-F]){1,4})){1,7}|:))|((([0-9a-fA-F]){1,4}):((:(([0-9a-fA-F]){1,4})){1,6}))|(((([0-9a-fA-F]){1,4}):){1,2}(:(([0-9a-fA-F]){1,4})){1,5})|(((([0-9a-fA-F]){1,4}):){1,3}(:(([0-9a-fA-F]){1,4})){1,4})|(((([0-9a-fA-F]){1,4}):){1,4}(:(([0-9a-fA-F]){1,4})){1,3})|(((([0-9a-fA-F]){1,4}):){1,5}(:(([0-9a-fA-F]){1,4})){1,2})|(((([0-9a-fA-F]){1,4}):){1,6}:(([0-9a-fA-F]){1,4}))|(((([0-9a-fA-F]){1,4}):){1,7}:)|(((([0-9a-fA-F]){1,4}):){7,7}(([0-9a-fA-F]){1,4})))(?!([^<]+)?>)/ig
-		$(this).html($(this).html().replace(pattern,'<span data-bs-toggle="tooltip" data-bs-html="true" data-bs-delay="500" title class="ip-addr">\$1</span>'))
-	})
+function find_ips(nodes) {
+  for (n of document.querySelectorAll(nodes)) {
+    const pattern =
+      /((((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))|(((([0-9a-fA-F]){1,4}):){1,4}:(((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])))|(::(ffff(:0{1,4}){0,1}:){0,1}(((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])))|(fe80:(:(([0-9a-fA-F]){1,4})){0,4}%[0-9a-zA-Z]{1,})|(:((:(([0-9a-fA-F]){1,4})){1,7}|:))|((([0-9a-fA-F]){1,4}):((:(([0-9a-fA-F]){1,4})){1,6}))|(((([0-9a-fA-F]){1,4}):){1,2}(:(([0-9a-fA-F]){1,4})){1,5})|(((([0-9a-fA-F]){1,4}):){1,3}(:(([0-9a-fA-F]){1,4})){1,4})|(((([0-9a-fA-F]){1,4}):){1,4}(:(([0-9a-fA-F]){1,4})){1,3})|(((([0-9a-fA-F]){1,4}):){1,5}(:(([0-9a-fA-F]){1,4})){1,2})|(((([0-9a-fA-F]){1,4}):){1,6}:(([0-9a-fA-F]){1,4}))|(((([0-9a-fA-F]){1,4}):){1,7}:)|(((([0-9a-fA-F]){1,4}):){7,7}(([0-9a-fA-F]){1,4})))(?!([^<]+)?>)/gi;
+    const replace =
+      '<span data-bs-toggle="tooltip" data-bs-html="true" data-bs-delay="500" title class="ip-addr">\$1</span>';
+    n.innerHTML = n.innerHTML.replace(pattern, replace);
+  }
 
-	$('span.ip-addr').each(function(){
-		$(this).attr('data-bs-original-title', centralops_tooltip($(this).text()))
-	})
+  for (const span of document.querySelectorAll("span.ip-addr")) {
+    span.setAttribute(
+      "data-bs-original-title",
+      centralops_tooltip(span.textContent),
+    );
+  }
 }
 
-function find_hashes(node) {
-	$(node).each(function(){
-		pattern = /([a-fA-F0-9]{32,64})(?!([^<]+)?>)/ig
-		$(this).html($(this).html().replace(pattern,'<span data-bs-toggle="tooltip" data-bs-html="true" data-bs-delay="500"title class="hash">\$1</span>'))
-	})
-
-	$('span.hash').each(function(){
-		$(this).attr('data-bs-original-title', virustotal_tooltip($(this).text()))
-	})
+function find_hashes(nodes) {
+  for (n of document.querySelectorAll(nodes)) {
+    const pattern = /([a-fA-F0-9]{32,64})(?!([^<]+)?>)/gi;
+    const replace =
+      '<span data-bs-toggle="tooltip" data-bs-html="true" data-bs-delay="500"title class="hash">\$1</span>';
+    n.innerHTML = n.innerHTML.replace(pattern, replace);
+  }
+  for (const span of document.querySelectorAll("span.hash")) {
+    span.setAttribute(
+      "data-bs-original-title",
+      virustotal_tooltip(span.textContent),
+    );
+  }
 }
 
-$(function () {
-	find_hostnames('.artifacts')
-	find_ips('.artifacts')
-	find_hashes('.artifacts')
+document.addEventListener("DOMContentLoaded", function () {
+  find_hostnames(".artifacts");
+  find_ips(".artifacts");
+  find_hashes(".artifacts");
 
-	const tooltipTriggerList = document.querySelectorAll('span.hostname, span.ip-addr, span.hash')
-	const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
+  const tooltipTriggerList = document.querySelectorAll(
+    "span.hostname, span.ip-addr, span.hash",
+  );
+  const tooltipList = [...tooltipTriggerList].map(
+    (tooltipTriggerEl) => new bootstrap.Tooltip(tooltipTriggerEl),
+  );
 });

--- a/fir_artifacts/static/fir_artifacts/js/upload.js
+++ b/fir_artifacts/static/fir_artifacts/js/upload.js
@@ -1,0 +1,99 @@
+async function delete_file(id) {
+  let csrftoken = document.querySelector("[name=csrfmiddlewaretoken]");
+
+  var response = await fetch(`/api/files/${id}`, {
+    method: "DELETE",
+    headers: {
+      Accept: "application/json",
+      "X-CSRFToken": csrftoken.value,
+    },
+  });
+
+  if (response.status != 204) {
+    console.error(await response.json());
+  } else {
+    document.location.reload();
+  }
+}
+
+function file_added(files) {
+  document.querySelector("div.upload").style.display = "none";
+  const table = document.getElementById("filetable");
+
+  table.innerHTML =
+    "<thead><tr><th>Filename</th><th>Description</th></tr></thead>";
+  for (f of files.files) {
+    const description = document.createElement("td");
+    description.textContent = f.name;
+
+    const input =
+      '<input type="text" name="description" class="input-medium file-descriptions" />';
+    table.innerHTML += `<tr>${description.outerHTML}<td>${input}</td></tr>`;
+  }
+}
+
+async function upload_files(id) {
+  let formData = new FormData();
+  for (f of document.getElementById("id_file").files) {
+    formData.append("file", f);
+  }
+  for (d of document.getElementsByClassName("file-descriptions")) {
+    formData.append("description", d.value);
+  }
+
+  let csrftoken = document.querySelector("[name=csrfmiddlewaretoken]");
+
+  var response = await fetch(`/api/files/${id}/upload`, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "X-CSRFToken": csrftoken.value,
+    },
+    body: formData,
+  });
+
+  if (response.status != 200) {
+    console.error(await response.json());
+  } else {
+    document.location.reload();
+  }
+}
+
+document.addEventListener("DOMContentLoaded", function () {
+  for (div of document.querySelectorAll(".details-file-delete")) {
+    div.addEventListener("click", function (event) {
+      event.preventDefault();
+      delete_file(div.dataset.id);
+    });
+  }
+
+  document
+    .getElementById("btn-upload")
+    .addEventListener("click", function (event) {
+      event.preventDefault();
+      upload_files(document.getElementById("upload_form").dataset.id);
+    });
+
+  document.getElementById("btn-browse").addEventListener("click", function () {
+    document.getElementById("id_file").click();
+  });
+
+  document
+    .getElementById("details-add-file")
+    .addEventListener("click", function () {
+      event.preventDefault();
+      const details = document.getElementById("details-files");
+      details.classList.remove("visually-hidden");
+      document.getElementById("id_file").click();
+    });
+
+  document
+    .getElementById("details-container")
+    .addEventListener("dragenter", function () {
+      document.querySelector("div.upload").style.display = "block";
+    });
+
+  document.getElementById("id_file").addEventListener("change", function () {
+    file_added(document.getElementById("id_file"));
+  });
+});

--- a/fir_artifacts/templates/fir_artifacts/plugins/details_sidebar.html
+++ b/fir_artifacts/templates/fir_artifacts/plugins/details_sidebar.html
@@ -2,36 +2,35 @@
 {% load fir_plugins %}
 {% load fir_artifacts %}
 {% load authorization %}
-{%  has_perm 'incidents.handle_incidents' obj=event as can_handle_incident %}
-<div class='widget border border-info-subtle {% if event.file_set.count == 0 %}visually-hidden{% endif%}' id='details-files'>
-<h4 class='widget text-info-emphasis bg-info-subtle border border-info-subtle'>{%  trans "Related files" %}</h4>
+{% has_perm "incidents.handle_incidents" obj=event as can_handle_incident %}
+<div class="widget border border-info-subtle {% if event.file_set.count == 0 %}visually-hidden{% endif %}" id="details-files">
+<h4 class="widget text-info-emphasis bg-info-subtle border border-info-subtle">{% trans "Related files" %}</h4>
     {% if event.file_set.count > 0 %}
-        <table class='table table-condensed files fixed'>
+        <table class="table table-condensed files fixed">
             <thead>
                 <tr>
-                    <th class="date-column">{%  trans "Date" %}</th>
-                    <th>{%  trans "File" %}</th>
-                    <th>{%  trans "Description" %}</th>
+                    <th class="date-column">{% trans "Date" %}</th>
+                    <th>{% trans "File" %}</th>
+                    <th>{% trans "Description" %}</th>
                     <th class="icon-column"></th>
                 </tr>
             </thead>
             {% for file in event.file_set.all %}
                 <tr>
-                    <td>{{file.date}}</td>
+                    <td>{{ file.date }}</td>
                     <td>
-                        <a href="{% url 'artifacts:download_file' file.id %}">
+                        <a href="/api/files/{{ file.id }}/download">
                             {{ file.getfilename }}
                         </a>
                     </td>
                     <td>{{ file.description }}</td>
                     <td class="icon-column">
                         {% if can_handle_incident %}
-                        <form id='details-file-delete' action="{% url 'artifacts:remove_file' file.id %}" method='POST'>
-                            {% csrf_token %}
+			<span class="details-file-delete" data-id="{{ file.id }}">
                             <button type="submit" class="btn btn-link btn-sm icon">
                                 <i class="bi bi-trash"></i>
                             </button>
-                        </form>
+                        </span>
                         {% endif %}
                     </td>
                 </tr>
@@ -39,24 +38,23 @@
         </table>
     {% endif %}
     {% if can_handle_incident %}
-    <form id='upload_form' enctype="multipart/form-data" action="{% url 'artifacts:upload_file' event|content_type event.id %}" method='POST'>
-        {% csrf_token %}
-        <div class='upload'>
-            <span>{%  trans "Dropzone" %}</span>
+    <div id="upload_form" data-id="{{ event.id }}">
+        <div class="upload">
+            <span>{% trans "Dropzone" %}</span>
             <input type="file" name="file" id="id_file" multiple />
         </div>
-        <table id='filetable' class='table table-condensed'></table>
+        <table id="filetable" class="table table-condensed"></table>
     </form>
-    <a class="btn btn-sm btn-default" href="#" onclick='javascript:$("#id_file").click();'>
-        <i class="bi bi-file-earmark"></i> {%  trans "Browse..." %}
+    <a class="btn btn-sm btn-default" href="#" id="btn-browse">
+        <i class="bi bi-file-earmark"></i> {% trans "Browse..." %}
     </a>
-    <a class="btn btn-sm btn-default" href="#" onclick='javascript:$("#upload_form").submit();'>
-        <i class="bi bi-upload"></i> {%  trans "Upload files" %}
+    <a class="btn btn-sm btn-default" href="#" id="btn-upload">
+        <i class="bi bi-upload"></i> {% trans "Upload files" %}
     </a>
     {% endif %}
     {% if event.file_set.count > 0 %}
-        <a class="btn btn-sm btn-default" href="{% url 'artifacts:download_archive' event|content_type event.id %}">
-            <i class="bi bi-download"></i> {%  trans "Download archive" %}
+        <a class="btn btn-sm btn-default" href="/api/files/{{ event.id }}/download-all">
+            <i class="bi bi-download"></i> {% trans "Download archive" %}
         </a>
     {% endif %}
 </div>
@@ -64,14 +62,14 @@
 
 {% if correlated_count > 0 %}
 	<div class="widget border border-info-subtle">
-		<h4 class='widget text-info-emphasis bg-info-subtle border border-info-subtle'>{%  trans "Correlated Artifacts" %}</h4>
+		<h4 class="widget text-info-emphasis bg-info-subtle border border-info-subtle">{% trans "Correlated Artifacts" %}</h4>
 
-		<div class='' id='sidebar_artifacts'>
-			<table class='table table-condensed artifacts-table artifacts fixed'>
+		<div id="sidebar_artifacts">
+			<table class="table table-condensed artifacts-table artifacts fixed">
     <thead>
         <tr>
-            <th class='head'>{%  trans "Type" %}</th>
-            <th>{%  trans "Values" %}</th>
+            <th class="head">{% trans "Type" %}</th>
+            <th>{% trans "Values" %}</th>
         </tr>
     </thead>
     {% for artifact_type in artifacts %}
@@ -81,3 +79,4 @@
 		</div>
 	</div>
 {% endif %}
+{% csrf_token %}

--- a/fir_artifacts/templates/fir_artifacts/plugins/details_static.html
+++ b/fir_artifacts/templates/fir_artifacts/plugins/details_static.html
@@ -1,3 +1,4 @@
 {% load static %}
 <script src="{% static "fir_artifacts/js/tooltips.js" %}"></script>
+<script src="{% static "fir_artifacts/js/upload.js" %}"></script>
 <script src="{% static "vendor/popper/popper.min.js" %}"></script>

--- a/fir_artifacts/templates/fir_artifacts/plugins/details_tab.html
+++ b/fir_artifacts/templates/fir_artifacts/plugins/details_tab.html
@@ -2,7 +2,7 @@
 
 {% if artifacts_count > 0 %}
 	<li class="nav-item">
-		<button class="nav-link" data-bs-target='#tab_artifacts' data-bs-toggle='tab'>
+		<button class="nav-link" data-bs-target="#tab_artifacts" data-bs-toggle="tab">
 			{% trans "Artifacts" %} ({{ artifacts_count }})
 		</button>
 	</li>

--- a/fir_artifacts/templates/fir_artifacts/plugins/details_tab_content.html
+++ b/fir_artifacts/templates/fir_artifacts/plugins/details_tab_content.html
@@ -1,23 +1,23 @@
 {% load i18n %}
 {% load fir_artifacts %}
 
-<div class='tab-pane' id='tab_artifacts'>
-	<div class='' id='artifacts'>
+<div class="tab-pane" id="tab_artifacts">
+	<div id="artifacts">
 		{% if event.file_set.count > 0 %}
-	<table class='table table-condensed files-table files fixed'>
-		<tr><th>{%  trans "Filename" %}</th><th>SHA-256</th><th>SHA-1</th><th>MD5</th></tr>
+	<table class="table table-condensed files-table files fixed">
+		<tr><th>{% trans "Filename" %}</th><th>SHA-256</th><th>SHA-1</th><th>MD5</th></tr>
 		{% for f in event.file_set.all %}
 			<tr><td>{{ f.getfilename }}</td>{{ f.hashes|hashes_line }}</tr>
 		{% endfor %}
 	</table>
 
-	<h3>{%  trans "Other artifacts" %}</h3>
+	<h3>{% trans "Other artifacts" %}</h3>
 {% endif %}
 
-<table class='table table-condensed artifacts-table artifacts'>
+<table class="table table-condensed artifacts-table artifacts">
 	<thead>
-		<th class='head'>{%  trans "Type" %}</th>
-		<th>{%  trans "Values" %}</th>
+		<th class="head">{% trans "Type" %}</th>
+		<th>{% trans "Values" %}</th>
 	</thead>
 	{% for artifact_type in artifacts %}
 		{{ artifact_type|display_artifact:request }}

--- a/fir_artifacts/urls.py
+++ b/fir_artifacts/urls.py
@@ -2,13 +2,17 @@ from django.urls import re_path
 
 from fir_artifacts import views
 
-app_name='fir_artifacts'
+app_name = "fir_artifacts"
 
 urlpatterns = [
-    re_path(r'^(?P<artifact_id>\d+)/detach/(?P<relation_name>\w+)/(?P<relation_id>\d+)/$', views.detach_artifact, name='detach'),
-    re_path(r'^(?P<artifact_id>\d+)/correlations/$', views.artifacts_correlations, name='correlations'),
-    re_path(r'^files/(?P<content_type>\d+)/upload/(?P<object_id>\d+)/$', views.upload_file, name='upload_file'),
-    re_path(r'^files/(?P<content_type>\d+)/archive/(?P<object_id>\d+)/$', views.download_archive, name='download_archive'),
-    re_path(r'^files/(?P<file_id>\d+)/remove/$', views.remove_file, name='remove_file'),
-    re_path(r'^files/(?P<file_id>\d+)/download/$', views.download, name='download_file'),
+    re_path(
+        r"^(?P<artifact_id>\d+)/detach/(?P<relation_name>\w+)/(?P<relation_id>\d+)/$",
+        views.detach_artifact,
+        name="detach",
+    ),
+    re_path(
+        r"^(?P<artifact_id>\d+)/correlations/$",
+        views.artifacts_correlations,
+        name="correlations",
+    ),
 ]

--- a/fir_artifacts/views.py
+++ b/fir_artifacts/views.py
@@ -3,7 +3,6 @@ from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.shortcuts import get_object_or_404, render, redirect
 from django.conf import settings
-from fir_artifacts.files import do_download_archive, do_download, do_upload_file, do_remove_file
 
 from incidents.views import is_incident_viewer
 
@@ -17,9 +16,15 @@ def artifacts_correlations(request, artifact_id):
     correlations = a.relations_for_user(request.user).group()
     if all([not link_type.objects.exists() for link_type in correlations.values()]):
         raise PermissionDenied
-    return render(request, 'fir_artifacts/correlation_list.html', {'correlations': correlations,
-                                                                   'artifact': a,
-                                                                   'incident_show_id': settings.INCIDENT_SHOW_ID})
+    return render(
+        request,
+        "fir_artifacts/correlation_list.html",
+        {
+            "correlations": correlations,
+            "artifact": a,
+            "incident_show_id": settings.INCIDENT_SHOW_ID,
+        },
+    )
 
 
 @login_required
@@ -32,29 +37,9 @@ def detach_artifact(request, artifact_id, relation_name, relation_id):
         related = relation.get(pk=relation_id)
     except:
         raise Http404("Unknown related object")
-    if not request.user.has_perm('incidents.handle_incidents', obj=related):
+    if not request.user.has_perm("incidents.handle_incidents", obj=related):
         raise PermissionDenied()
     a.relations.remove(related)
     if a.relations.count() == 0:
         a.delete()
-    return redirect('%s:details' % relation_name, relation_id)
-
-
-@login_required
-def download_archive(request, content_type, object_id):
-    return do_download_archive(request, content_type, object_id)
-
-
-@login_required
-def download(request, file_id):
-    return do_download(request, file_id)
-
-
-@login_required
-def upload_file(request, content_type, object_id):
-    return do_upload_file(request, content_type, object_id)
-
-
-@login_required
-def remove_file(request, file_id):
-    return do_remove_file(request, file_id)
+    return redirect("%s:details" % relation_name, relation_id)

--- a/incidents/static/custom_js/details_actions.js
+++ b/incidents/static/custom_js/details_actions.js
@@ -9,39 +9,6 @@ $(function () {
     $(".details-actions-supmenu").hide();
   });
 
-  //
-  // File Uploads
-  //
-  $("#details-add-file").click(function (event) {
-    $("#details-files").removeClass("visually-hidden");
-    $("#id_file").click();
-    event.preventDefault();
-  });
-
-  $("#id_file").change(function () {
-    $("div.upload").hide();
-    var files = $(this)[0].files;
-
-    $("#filetable").empty();
-    $("#filetable").append(
-      "<thead><tr><th>Filename</th><th>Description</th></tr></thead>",
-    );
-    for (var i = 0; i < files.length; i++) {
-      var input =
-        "<input type='text' name='description' class='input-medium' />";
-      $("#filetable").append(
-        "<tr><td>" +
-          files[i].name.replace(/</g, "&lt;").replace(/>/g, "&gt;") +
-          "</td><td>" +
-          input +
-          "</td></tr>",
-      );
-    }
-  });
-
-  $("#details-container").on("dragenter", function (e) {
-    $("div.upload").show();
-  });
 
   //
   // Attributes


### PR DESCRIPTION
This PR rework how files are uploaded/downloaded in FIR: The GUI now use API endpoints to upload or download files. Old custom-made endpoints are removed.

In addition, this PR removes the usage of Jquery for artifacts management.