### PR TITLE
Fix alerting submenu not showing when an incident is assigned to multiple BLs

### DIFF
--- a/fir_alerting/static/fir_alerting/js/alerting.js
+++ b/fir_alerting/static/fir_alerting/js/alerting.js
@@ -105,7 +105,7 @@ $(function () {
   $('#details-actions-alert').click(function (event) {
     if ($(this).data('url') == undefined) {
       $(".details-actions-supmenu").addClass("visually-hidden");
-      $('#details-actions-alert-bls').show();
+      $('#details-actions-alert-bls').removeClass("visually-hidden");
       event.preventDefault();
     }
     else {


### PR DESCRIPTION
When an incident is assigned to multiple BLs, clicking on "alert" does not display the alerting submenu. This PR fixes the issue