### PR TITLE
Rework API permissions: add support for event_reporter, INCIDENT_VIEWER_CAN_COMMENT

### DIFF
--- a/fir_api/permissions.py
+++ b/fir_api/permissions.py
@@ -1,38 +1,84 @@
 from rest_framework.permissions import BasePermission, IsAdminUser, SAFE_METHODS
-from incidents.models import Incident, AccessControlEntry
+from incidents.models import AccessControlEntry, BusinessLine, Incident
+from django.conf import settings
 
 
-class IsIncidentHandler(BasePermission):
+class BaseIncidentPermission(BasePermission):
+    def get_incident_bls(self, obj):
+        if hasattr(obj, "incident"):
+            obj = obj.incident
+        return obj.concerned_business_lines.all()
+
+    def has_perm(self, user, perm, bls):
+        return user.has_perm(perm) or any(user.has_perm(perm, bl) for bl in bls)
+
+    def is_handler(self, user, bls):
+        return self.has_perm(user, "incidents.handle_incidents", bls)
+
+    def is_writer(self, user, bls):
+        return self.has_perm(user, "incidents.report_events", bls)
+
+    def is_viewer(self, user, bls):
+        return self.has_perm(user, "incidents.view_incidents", bls)
+
+
+class CanViewIncident(BaseIncidentPermission):
     def has_permission(self, request, view):
-        # Checks for handle_incidents permissions for non GET requests
-        if request.method == "GET":
-            return True
-        if request.user.has_perm("incidents.handle_incidents"):
-            return True
-        # Get any possible access control entries that would allow the user
-        # to perform actions from handle_incidents perspective
-        user_access_controls = AccessControlEntry.objects.filter(
-            user=request.user, role__permissions__codename="handle_incidents"
-        )
-        if user_access_controls:
-            return True
-        return False
+        return request.method in SAFE_METHODS
 
     def has_object_permission(self, request, view, obj):
-        try:
-            if type(obj) == Incident:
-                incident = obj
-            elif hasattr(obj, "incident"):
-                incident = obj.incident
-            else:
-                # The object is not related to an incident (ValidAttribute, etc)
-                return True
-            Incident.authorization.for_user(
-                request.user, "incidents.view_incidents"
-            ).get(pk=incident.id)
-            return True
-        except:
+        if request.method not in SAFE_METHODS:
             return False
+        bls = self.get_incident_bls(obj)
+        return self.is_viewer(request.user, bls) or self.is_handler(request.user, bls)
+
+
+class CanWriteIncident(BaseIncidentPermission):
+    def has_permission(self, request, view):
+        return request.method not in SAFE_METHODS
+
+    def has_object_permission(self, request, view, obj):
+        if request.method in SAFE_METHODS:
+            return False
+        bls = self.get_incident_bls(obj)
+        return self.is_writer(request.user, bls) or self.is_handler(request.user, bls)
+
+
+class CanViewComment(BaseIncidentPermission):
+    def has_permission(self, request, view):
+        return request.method in SAFE_METHODS
+
+    def has_object_permission(self, request, view, obj):
+        if request.method not in SAFE_METHODS:
+            return False
+        bls = self.get_incident_bls(obj)
+        return self.is_viewer(request.user, bls) or self.is_handler(request.user, bls)
+
+
+class CanWriteComment(BaseIncidentPermission):
+    def has_permission(self, request, view):
+        return request.method not in SAFE_METHODS
+
+    def has_object_permission(self, request, view, obj):
+        bls = self.get_incident_bls(obj)
+        user = request.user
+
+        if self.is_handler(user, bls):
+            return True
+
+        if request.method == "POST":
+            return self.is_writer(user, bls) or (
+                settings.INCIDENT_VIEWER_CAN_COMMENT and self.is_viewer(user, bls)
+            )
+
+        if request.method in ["PUT", "PATCH"]:
+            return (
+                settings.INCIDENT_VIEWER_CAN_COMMENT
+                and hasattr(obj, "opened_by")
+                and obj.opened_by == user
+            )
+
+        return False
 
 
 class IsAdminUserOrReadOnly(IsAdminUser):

--- a/fir_api/views.py
+++ b/fir_api/views.py
@@ -56,10 +56,12 @@ from fir_api.filters import (
     StatusFilter,
 )
 from fir_api.permissions import (
-    IsIncidentHandler,
+    CanWriteIncident,
+    CanViewIncident,
+    CanWriteComment,
+    CanViewComment,
     IsAdminUserOrReadOnly,
 )
-from fir_api.permissions import IsIncidentHandler
 from incidents.models import (
     Incident,
     Comments,
@@ -134,7 +136,7 @@ class IncidentViewSet(
     """
 
     serializer_class = IncidentSerializer
-    permission_classes = [IsAuthenticated, IsIncidentHandler]
+    permission_classes = [IsAuthenticated, CanViewIncident | CanWriteIncident]
     filter_backends = [DjangoFilterBackend, OrderingFilter]
     ordering_fields = [
         "id",
@@ -273,7 +275,7 @@ class CommentViewSet(viewsets.ModelViewSet):
     """
 
     serializer_class = CommentsSerializer
-    permission_classes = [IsAuthenticated, IsIncidentHandler]
+    permission_classes = [IsAuthenticated, CanViewComment | CanWriteComment]
     filter_backends = [DjangoFilterBackend, OrderingFilter]
     ordering_fields = ["id", "date"]
     filterset_class = CommentFilter
@@ -328,7 +330,7 @@ class AttributeViewSet(viewsets.ModelViewSet):
     """
 
     serializer_class = AttributeSerializer
-    permission_classes = [IsAuthenticated, IsIncidentHandler]
+    permission_classes = [IsAuthenticated, CanViewIncident | CanWriteIncident]
     filter_backends = [DjangoFilterBackend, OrderingFilter]
     ordering_fields = ["id", "name", "value", "incident"]
     filterset_class = AttributeFilter
@@ -390,7 +392,7 @@ class ValidAttributeViewSet(viewsets.ModelViewSet):
 
     queryset = ValidAttribute.objects.all().order_by("id")
     serializer_class = ValidAttributeSerializer
-    permission_classes = [IsAuthenticated, IsIncidentHandler]
+    permission_classes = [IsAuthenticated, IsAdminUserOrReadOnly]
     filter_backends = [DjangoFilterBackend, OrderingFilter]
     ordering_fields = ["id", "name", "unit", "description", "categories"]
     filterset_class = ValidAttributeFilter

--- a/fir_artifacts/api.py
+++ b/fir_artifacts/api.py
@@ -19,7 +19,7 @@ from rest_framework.mixins import (
 )
 
 from incidents.models import Incident
-from fir_api.permissions import IsIncidentHandler
+from fir_api.permissions import CanViewIncident, CanWriteIncident
 from fir_artifacts.models import File, Artifact
 from fir_artifacts.files import handle_uploaded_file, do_download, do_download_archive
 
@@ -59,6 +59,7 @@ class ArtifactSerializer(serializers.ModelSerializer):
     """
     Serializer for /api/artifacts
     """
+
     class Meta:
         model = Artifact
         fields = ("id", "type", "value", "incidents")
@@ -69,6 +70,7 @@ class IncidentArtifactSerializer(serializers.ModelSerializer):
     """
     Serializer for /api/incident/<id>
     """
+
     incidents_count = serializers.IntegerField(source="incidents.count", read_only=True)
 
     class Meta:
@@ -98,7 +100,7 @@ class FileViewSet(
     """
 
     serializer_class = FileSerializer
-    permission_classes = [IsAuthenticated, IsIncidentHandler]
+    permission_classes = [IsAuthenticated, CanViewIncident | CanWriteIncident]
     filter_backends = [DjangoFilterBackend, OrderingFilter]
     ordering_fields = ["id", "date", "incident"]
     filterset_class = FileFilter
@@ -174,7 +176,7 @@ class ArtifactViewSet(ListModelMixin, RetrieveModelMixin, viewsets.GenericViewSe
     """
 
     serializer_class = ArtifactSerializer
-    permission_classes = [IsAuthenticated, IsIncidentHandler]
+    permission_classes = [IsAuthenticated, CanViewIncident | CanWriteIncident]
     filter_backends = [DjangoFilterBackend, OrderingFilter]
     ordering_fields = ["id", "type", "value"]
     filterset_class = ArtifactFilter

--- a/fir_nuggets/api.py
+++ b/fir_nuggets/api.py
@@ -10,7 +10,7 @@ from django_filters.rest_framework import (
     NumberFilter,
 )
 
-from fir_api.permissions import IsIncidentHandler
+from fir_api.permissions import CanViewIncident, CanWriteIncident
 from fir_nuggets.models import Nugget
 from incidents.models import Incident
 
@@ -63,7 +63,7 @@ class NuggetViewSet(viewsets.ModelViewSet):
 
     queryset = Nugget.objects.all()
     serializer_class = NuggetSerializer
-    permission_classes = (IsAuthenticated, IsIncidentHandler)
+    permission_classes = [IsAuthenticated, CanViewIncident | CanWriteIncident]
     filter_backends = [DjangoFilterBackend, OrderingFilter]
     ordering_fields = [
         "id",

--- a/fir_todos/api.py
+++ b/fir_todos/api.py
@@ -10,7 +10,7 @@ from django_filters.rest_framework import (
     BooleanFilter,
 )
 
-from fir_api.permissions import IsIncidentHandler
+from fir_api.permissions import CanViewIncident, CanWriteIncident
 from fir_todos.models import TodoItem
 from incidents.models import BusinessLine, Incident
 
@@ -66,7 +66,7 @@ class TodoViewSet(viewsets.ModelViewSet):
 
     queryset = TodoItem.objects.all()
     serializer_class = TodoSerializer
-    permission_classes = (IsAuthenticated, IsIncidentHandler)
+    permission_classes = [IsAuthenticated, CanViewIncident | CanWriteIncident]
     filter_backends = [DjangoFilterBackend, OrderingFilter]
     ordering_fields = ["id", "incident", "done_time"]
     filterset_class = TodoFilter
@@ -75,7 +75,9 @@ class TodoViewSet(viewsets.ModelViewSet):
         incidents_allowed = Incident.authorization.for_user(
             self.request.user, "incidents.view_incidents"
         )
-        queryset = TodoItem.objects.filter(incident__in=incidents_allowed).order_by("-id")
+        queryset = TodoItem.objects.filter(incident__in=incidents_allowed).order_by(
+            "-id"
+        )
         return queryset
 
     def perform_create(self, serializer):


### PR DESCRIPTION
This PR rework API permissions and add support for event_reporter (write-only) users. 

The PR also makes the API honor the config parameter "INCIDENT_VIEWER_CAN_COMMENT", which can be defined in the config by an administrator.