### PR TITLE
Fix stats in sandbox/attributes not working when filtering on one or multiple sub-BLs

### DIFF
--- a/fir_stats/static/fir_stats/stats.js
+++ b/fir_stats/static/fir_stats/stats.js
@@ -1577,7 +1577,7 @@ function getOtherFiltersArg(force_unit = false, with_attribute_only = false) {
 
     let bls = document.getElementById("id_concerned_business_lines");
     if (form.get("concerned_business_lines") && bls) {
-      options = Array.from(bls.selectedOptions).map(({ text }) => text);
+      options = Array.from(bls.selectedOptions).map(({ text }) => text.split(" > ").at(-1));
       for (let o of options) {
         filters += `&concerned_business_lines=${encodeURIComponent(o)}`;
       }


### PR DESCRIPTION
When filtering on one or multiple BLs, stats are currently not working (returning empty results). This PR fixes the issue.