### PR TITLE
API: improve `comments` endpoints

### DIFF
--- a/incidents/models.py
+++ b/incidents/models.py
@@ -425,7 +425,10 @@ class Comments(models.Model):
 
     @classmethod
     def create_diff_comment(cls, incident, data, user):
-        new = data.get("status", None)
+        if isinstance(data, Incident):
+            new = getattr(data, "status", None)
+        else:
+            new = data.get("status", None)
         old = getattr(incident, "status", None)
 
         if new is not None and new != old:


### PR DESCRIPTION
This PR 

- Adds two new fields when viewing comments: `can_edit`, `parsed_comments`.
- Change the incident status when adding a comment, if the action is associated with a status.